### PR TITLE
NearOnEthClinet: add message for BP num limit

### DIFF
--- a/contracts/eth/nearbridge/contracts/NearBridge.sol
+++ b/contracts/eth/nearbridge/contracts/NearBridge.sol
@@ -261,7 +261,7 @@ contract NearBridge is INearBridge, AdminControlled {
 
     function setBlockProducers(NearDecoder.BlockProducer[] memory src, Epoch storage epoch) internal {
         uint cnt = src.length;
-        require(cnt <= MAX_BLOCK_PRODUCERS);
+        require(cnt <= MAX_BLOCK_PRODUCERS, "It is not expected having that many block producers for the provided block");
         epoch.numBPs = cnt;
         unchecked {
             for (uint i = 0; i < cnt; i++) {


### PR DESCRIPTION
* Add an explicit message if the number of block producers for the provided block is bigger than `MAX_BLOCK_PRODUCERS`

Without the message, it becomes really hard to debug if something goes wrong.

NB: as Near Testnet currently allows having >100 Validators, it makes sense to consider changing the number of `MAX_BLOCK_PRODUCERS` to something meaningful in the future (maybe 256?)