### PR TITLE
NearOnEth client :increase max num of BPs. Near2Eth-relayer improvements

### DIFF
--- a/contracts/eth/nearbridge/contracts/NearBridge.sol
+++ b/contracts/eth/nearbridge/contracts/NearBridge.sol
@@ -11,7 +11,7 @@ contract NearBridge is INearBridge, AdminControlled {
     using NearDecoder for Borsh.Data;
 
     // Assumed to be even and to not exceed 256.
-    uint constant MAX_BLOCK_PRODUCERS = 100;
+    uint constant MAX_BLOCK_PRODUCERS = 140;
 
     struct Epoch {
         bytes32 epochId;

--- a/near2eth/near2eth-block-relay/index.js
+++ b/near2eth/near2eth-block-relay/index.js
@@ -64,9 +64,11 @@ class Near2EthRelay {
         // Get most recent block from Near blockchain.
         const status = await this.near.connection.provider.status()
         // Get the block two blocks before that, to make sure it is final.
+        const blockId = status.sync_info.latest_block_height - 2;
         const headBlock = await this.near.connection.provider.block({
-          blockId: status.sync_info.latest_block_height
+          blockId: blockId
         })
+        console.log(`Initializing with head block at: ${blockId}`);
         const lastFinalBlockHash = headBlock.header.last_final_block
         // The finalized block is not immediately available so we wait for it to become available.
         let lightClientBlock = null
@@ -90,6 +92,7 @@ class Near2EthRelay {
         }
         console.log('Initializing with validators')
         console.log(`${JSON.stringify(currentValidators)}`)
+        console.log(`Num validators: ${currentValidators.length}`);
         const borshInitialValidators = borshifyInitialValidators(
           currentValidators
         )
@@ -101,7 +104,7 @@ class Near2EthRelay {
               .initWithValidators(borshInitialValidators)
               .send({
                 from: this.ethMasterAccount,
-                gas: 4000000,
+                gas: 6000000,
                 handleRevert: true,
                 gasPrice
               })
@@ -122,12 +125,13 @@ class Near2EthRelay {
 
         console.log('Initializing with block')
         console.log(`${JSON.stringify(lightClientBlock)}`)
+        console.log(`Num validators: ${lightClientBlock.next_bps.length}`);
         const borshBlock = borshify(lightClientBlock)
         for (let i = 0; i < 10; i++) {
           try {
             await this.clientContract.methods.initWithBlock(borshBlock).send({
               from: this.ethMasterAccount,
-              gas: 4000000,
+              gas: 6000000,
               handleRevert: true,
               gasPrice: new BN(await this.web3.eth.getGasPrice()).mul(
                 new BN(ethGasMultiplier)


### PR DESCRIPTION
* NearOnEth light client: increase max number of block producers to 140.
* Near2Eth relayer: use 2 blocks before the latest one as a block head.
* Near2Eth relayer: increase gas limit for the initialization stage.
* Near2Eth relayer: add more logs