### PR TITLE
fix a bug validate the epoch header using the previous validator set

### DIFF
--- a/contracts/near/eth-client/src/lib.rs
+++ b/contracts/near/eth-client/src/lib.rs
@@ -574,14 +574,10 @@ impl EthClient {
 
     // check if the author address is valid and is in the validator set.
     #[cfg(feature = "bsc")]
-    fn bsc_is_validator(&self, header: &BlockHeader) -> bool {
+    pub fn bsc_is_validator(&self, header: &BlockHeader) -> bool {
         let (extra_vanity, extra_seal, address_size) = (32, 65, 20);
 
-        let epoch_header = if EthClient::is_epoch(header.number) {
-            header.clone()
-        } else {
-            self.bsc_get_epoch_header()
-        };
+        let epoch_header = self.bsc_get_epoch_header();
 
         if !self.bsc_is_in_validator_set(&epoch_header, header.author) {
             return false;

--- a/contracts/near/eth-client/src/lib.rs
+++ b/contracts/near/eth-client/src/lib.rs
@@ -574,7 +574,7 @@ impl EthClient {
 
     // check if the author address is valid and is in the validator set.
     #[cfg(feature = "bsc")]
-    pub fn bsc_is_validator(&self, header: &BlockHeader) -> bool {
+    fn bsc_is_validator(&self, header: &BlockHeader) -> bool {
         let (extra_vanity, extra_seal, address_size) = (32, 65, 20);
 
         let epoch_header = self.bsc_get_epoch_header();

--- a/contracts/near/eth-client/src/tests.rs
+++ b/contracts/near/eth-client/src/tests.rs
@@ -597,6 +597,39 @@ fn bsc_add_epoch_header() {
     assert!(hashes[0] == contract.epoch_header)
 }
 
+#[test]
+#[cfg_attr(not(feature = "bsc"), ignore)]
+fn bsc_validate_epoch_headers_validator() {
+    let chain_id = 97;
+    let start = 10_160_000;
+    let end = 10_165_000;
+    let mut current = start;
+    
+    testing_env!(get_context(vec![], false));
+    while current <= end {
+        println!("Current block {}", current);
+
+        let (blocks, _) = get_blocks(&BSC_WEB3RS, current - 200, current -200 +1);
+        let contract = EthClient::init(
+            true,
+            String::from("bsc"),
+            0,
+            vec![],
+            blocks[0].clone(),
+            30,
+            201,
+            201,
+            None,
+            chain_id,
+        );
+        for block in blocks.into_iter() {
+            let header: BlockHeader = rlp::decode(block.as_slice()).unwrap();
+            contract.bsc_is_validator(&header);
+        }
+        current += 200;
+    }
+}
+
 // test validate bsc headers.
 #[test]
 #[cfg_attr(not(feature = "bsc"), ignore)]


### PR DESCRIPTION
Hello Guys!!
I fixed a 1 million bounty bug 😂😂
 
This is a fix for a bug that happens on the epoch headers.
before this fix, the epoch headers was validated with the new validator set but this makes the validation fails on some epochs (1750200, 11693400, 12819400).

you can see [here](https://github.com/binance-chain/bsc/blob/master/consensus/parlia/parlia.go#L553) that they use the previous snapshot to validate the new header.