### PR TITLE
BSC client: remove zero block trust

### DIFF
--- a/contracts/near/eth-client/src/lib.rs
+++ b/contracts/near/eth-client/src/lib.rs
@@ -470,11 +470,6 @@ impl EthClient {
     //  Verify POSA of the binance chain header.
     #[cfg(feature = "bsc")]
     fn bsc_verify_header(&self, header: &BlockHeader, prev: &BlockHeader) -> bool {
-        // The genesis block is the always valid dead-end
-        if header.number == 0 {
-            return true;
-        }
-
         // verify basic header properties.
         if !self.verify_basic(header, prev) {
             return false;


### PR DESCRIPTION
This rule doesn't produce any useful impact as we don't suppose to run the light-client from the genesis block. Meantime, the rule is dangerous from the security point of view as it relies on further validation in other parts of the code.

Related #672.