### PR TITLE
EthOnNearClient: fix pre-London block deserialization

### DIFF
--- a/contracts/near/eth-client/src/tests.rs
+++ b/contracts/near/eth-client/src/tests.rs
@@ -242,6 +242,7 @@ fn assert_hashes_equal_to_contract_hashes(contract: &EthClient, heights: &[u64],
 }
 
 #[test]
+#[cfg_attr(feature = "eip1559", ignore)]
 fn add_dags_merkle_roots() {
     testing_env!(get_context(vec![], false));
     let (blocks, _) = get_blocks(&WEB3RS, 400_000, 400_001);
@@ -267,6 +268,7 @@ fn add_dags_merkle_roots() {
 }
 
 #[test]
+#[cfg_attr(feature = "eip1559", ignore)]
 fn add_blocks_2_and_3() {
     testing_env!(get_context(vec![], false));
 
@@ -305,6 +307,7 @@ fn add_blocks_2_and_3() {
 }
 
 #[test]
+#[cfg_attr(feature = "eip1559", ignore)]
 fn add_blocks_before_and_after_istanbul_fork() {
     testing_env!(get_context(vec![], false));
 
@@ -355,6 +358,7 @@ fn add_blocks_before_and_after_istanbul_fork() {
 }
 
 #[test]
+#[cfg_attr(feature = "eip1559", ignore)]
 fn add_blocks_before_and_after_nov11_2020_unannounced_fork() {
     testing_env!(get_context(vec![], false));
 
@@ -404,6 +408,7 @@ fn add_blocks_before_and_after_nov11_2020_unannounced_fork() {
 }
 
 #[test]
+#[cfg_attr(feature = "eip1559", ignore)]
 fn add_block_diverged_until_ethashproof_dataset_fix() {
     testing_env!(get_context(vec![], false));
 
@@ -428,6 +433,7 @@ fn add_block_diverged_until_ethashproof_dataset_fix() {
 }
 
 #[test]
+#[cfg_attr(feature = "eip1559", ignore)]
 fn add_400000_block_only() {
     testing_env!(get_context(vec![], false));
 
@@ -457,6 +463,7 @@ fn add_400000_block_only() {
 }
 
 #[test]
+#[cfg_attr(feature = "eip1559", ignore)]
 fn add_two_blocks_from_8996776() {
     testing_env!(get_context(vec![], false));
 
@@ -502,6 +509,7 @@ fn add_two_blocks_from_8996776() {
 }
 
 #[test]
+#[cfg_attr(feature = "eip1559", ignore)]
 fn add_two_blocks_from_400000() {
     testing_env!(get_context(vec![], false));
 

--- a/contracts/near/eth-client/test.sh
+++ b/contracts/near/eth-client/test.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 
+# Run without default features
+RUST_BACKTRACE=1 cargo test --no-default-features --jobs 8 --package eth-client -- --nocapture
+# Run with default features
 RUST_BACKTRACE=1 cargo test --jobs 8 --package eth-client -- --nocapture

--- a/contracts/near/eth-types/src/lib.rs
+++ b/contracts/near/eth-types/src/lib.rs
@@ -299,8 +299,8 @@ impl From<BlockHeaderPreLondon> for BlockHeader {
 
 impl BorshDeserialize for BlockHeader {
     fn deserialize(buf: &mut &[u8]) -> std::io::Result<Self> {
-        if let Ok(header) = BlockHeaderLondon::deserialize(buf) {
-            Ok(header.into())
+        if let Ok(_header) = BlockHeaderLondon::try_from_slice(buf) {
+            BlockHeaderLondon::deserialize(buf).map(Into::into)
         } else {
             BlockHeaderPreLondon::deserialize(buf).map(Into::into)
         }


### PR DESCRIPTION
Summary:
* EthOnNearClient: fix pre-London block deserialization 
* Don't run pre-London tests when the EIP-1559 feature is active.
* Run both test suites: with and without default features (with and
  without EIP-1559 support).

The issue happened as `BorshDeserialize::deserialize()` modifies the buffer so if the attempt to deserialize to London black fails, the buffer is already updated and it can not be deserialized as a pre-London block anymore. However, I don't really like that approach as it requires twice-deserialization for the London blocks. We can manually shift the buffer if the deserialization of the London block is successful too.

Fixes #682.