### PR TITLE
CI: disable old tests prior to nearcore 1.23.0.

### DIFF
--- a/contracts/eth/nearbridge/test/NearBridge.js
+++ b/contracts/eth/nearbridge/test/NearBridge.js
@@ -23,67 +23,73 @@ beforeEach(async function () {
     await NearBridge.deposit({ value: ethers.utils.parseEther('1') });
 });
 
-//it('should be ok', async function () {
-//    const block120998 = borshify(require('./block_120998.json'));
-//    const block121498 = borshify(require('./block_121498.json'));
-//    const block121998 = borshify(require('./block_121998.json'));
-//
-//    // We should use previous epoch's next_bps to initWithBlock with block_120998, but they happens to be same
-//    await NearBridge.initWithValidators(borshifyInitialValidators(require('./block_120998.json').next_bps));
-//    await NearBridge.initWithBlock(block120998);
-//    expect(await NearBridge.blockHashes(120998)).to.be.equal(
-//        '0x1a7a07b5eee1f4d8d7e47864d533143972f858464bacdc698774d167fb1b40e6',
-//    );
-//
-//    await NearBridge.addLightClientBlock(block121498);
-//    expect(await NearBridge.checkBlockProducerSignatureInHead(0)).to.be.true;
-//
-//    await expect(NearBridge.addLightClientBlock(block121998)).to.be.revertedWith('Epoch id of the block is not valid');
-//    await increaseTime(3600);
-//    expect(await NearBridge.blockHashes(121498)).to.be.equal(
-//        '0x508307e7af9bdbb297afa7af0541130eb32f0f028151319f5a4f7ae68b0ecc56',
-//    );
-//
-//    await NearBridge.addLightClientBlock(block121998);
-//    expect(await NearBridge.checkBlockProducerSignatureInHead(0)).to.be.true;
-//
-//    await increaseTime(3600);
-//    expect(await NearBridge.blockHashes(121998)).to.be.equal(
-//        '0x2358c4881bbd111d2e4352b6a7e6c7595fb39d3c9897d3c624006be1ef809abf',
-//    );
-//});
+it('should be ok', async function () {
+    // Skip until tests are upgraded having blocks after nearcore 1.23.0
+    this.skip();
 
-//if (process.env.NEAR_HEADERS_DIR) {
-//    it('ok with many block headers', async function () {
-//        this.timeout(0);
-//        const blockFiles = await fs.readdir(process.env.NEAR_HEADERS_DIR);
-//        blockFiles.sort((a, b) => a.split('.')[0] - b.split('.')[0]);
-//        const firstBlock = require(process.env.NEAR_HEADERS_DIR + '/' + blockFiles[0]);
-//        const firstBlockBorsh = borshify(firstBlock);
-//        // current bps happens to equal to next_bps
-//        await NearBridge.initWithValidators(borshifyInitialValidators(firstBlock.next_bps));
-//        await NearBridge.initWithBlock(firstBlockBorsh);
-//        await NearBridge.blockHashes(firstBlock.inner_lite.height);
-//        expect(await NearBridge.blockHashes(firstBlock.inner_lite.height)).to.be.a('string');
-//
-//        for (let i = 1; i < blockFiles.length; i++) {
-//            const block = require(process.env.NEAR_HEADERS_DIR + '/' + blockFiles[i]);
-//            const blockBorsh = borshify(block);
-//            console.log('adding block ' + block.inner_lite.height);
-//            await NearBridge.addLightClientBlock(blockBorsh);
-//            await NearBridge.blockHashes(block.inner_lite.height);
-//            await increaseTime(3600);
-//
-//            if (i >= 600) {
-//                console.log('checking block ' + block.inner_lite.height);
-//                for (let j = 0; j < block.approvals_after_next.length; j++) {
-//                    console.log('checking approval ' + j);
-//                    if (block.approvals_after_next[j]) {
-//                        console.log('approval ' + j + ' is not null');
-//                        expect(await NearBridge.checkBlockProducerSignatureInHead(j)).to.be.true;
-//                    }
-//                }
-//            }
-//        }
-//    });
-//}
+    const block120998 = borshify(require('./block_120998.json'));
+    const block121498 = borshify(require('./block_121498.json'));
+    const block121998 = borshify(require('./block_121998.json'));
+
+    // We should use previous epoch's next_bps to initWithBlock with block_120998, but they happens to be same
+    await NearBridge.initWithValidators(borshifyInitialValidators(require('./block_120998.json').next_bps));
+    await NearBridge.initWithBlock(block120998);
+    expect(await NearBridge.blockHashes(120998)).to.be.equal(
+        '0x1a7a07b5eee1f4d8d7e47864d533143972f858464bacdc698774d167fb1b40e6',
+    );
+
+    await NearBridge.addLightClientBlock(block121498);
+    expect(await NearBridge.checkBlockProducerSignatureInHead(0)).to.be.true;
+
+    await expect(NearBridge.addLightClientBlock(block121998)).to.be.revertedWith('Epoch id of the block is not valid');
+    await increaseTime(3600);
+    expect(await NearBridge.blockHashes(121498)).to.be.equal(
+        '0x508307e7af9bdbb297afa7af0541130eb32f0f028151319f5a4f7ae68b0ecc56',
+    );
+
+    await NearBridge.addLightClientBlock(block121998);
+    expect(await NearBridge.checkBlockProducerSignatureInHead(0)).to.be.true;
+
+    await increaseTime(3600);
+    expect(await NearBridge.blockHashes(121998)).to.be.equal(
+        '0x2358c4881bbd111d2e4352b6a7e6c7595fb39d3c9897d3c624006be1ef809abf',
+    );
+});
+
+if (process.env.NEAR_HEADERS_DIR) {
+    it('ok with many block headers', async function () {
+        // Skip until tests are upgraded having blocks after nearcore 1.23.0
+        this.skip();
+
+        this.timeout(0);
+        const blockFiles = await fs.readdir(process.env.NEAR_HEADERS_DIR);
+        blockFiles.sort((a, b) => a.split('.')[0] - b.split('.')[0]);
+        const firstBlock = require(process.env.NEAR_HEADERS_DIR + '/' + blockFiles[0]);
+        const firstBlockBorsh = borshify(firstBlock);
+        // current bps happens to equal to next_bps
+        await NearBridge.initWithValidators(borshifyInitialValidators(firstBlock.next_bps));
+        await NearBridge.initWithBlock(firstBlockBorsh);
+        await NearBridge.blockHashes(firstBlock.inner_lite.height);
+        expect(await NearBridge.blockHashes(firstBlock.inner_lite.height)).to.be.a('string');
+
+        for (let i = 1; i < blockFiles.length; i++) {
+            const block = require(process.env.NEAR_HEADERS_DIR + '/' + blockFiles[i]);
+            const blockBorsh = borshify(block);
+            console.log('adding block ' + block.inner_lite.height);
+            await NearBridge.addLightClientBlock(blockBorsh);
+            await NearBridge.blockHashes(block.inner_lite.height);
+            await increaseTime(3600);
+
+            if (i >= 600) {
+                console.log('checking block ' + block.inner_lite.height);
+                for (let j = 0; j < block.approvals_after_next.length; j++) {
+                    console.log('checking approval ' + j);
+                    if (block.approvals_after_next[j]) {
+                        console.log('approval ' + j + ' is not null');
+                        expect(await NearBridge.checkBlockProducerSignatureInHead(j)).to.be.true;
+                    }
+                }
+            }
+        }
+    });
+}

--- a/contracts/eth/nearbridge/test/NearBridge.js
+++ b/contracts/eth/nearbridge/test/NearBridge.js
@@ -23,35 +23,35 @@ beforeEach(async function () {
     await NearBridge.deposit({ value: ethers.utils.parseEther('1') });
 });
 
-it('should be ok', async function () {
-    const block120998 = borshify(require('./block_120998.json'));
-    const block121498 = borshify(require('./block_121498.json'));
-    const block121998 = borshify(require('./block_121998.json'));
-
-    // We should use previous epoch's next_bps to initWithBlock with block_120998, but they happens to be same
-    await NearBridge.initWithValidators(borshifyInitialValidators(require('./block_120998.json').next_bps));
-    await NearBridge.initWithBlock(block120998);
-    expect(await NearBridge.blockHashes(120998)).to.be.equal(
-        '0x1a7a07b5eee1f4d8d7e47864d533143972f858464bacdc698774d167fb1b40e6',
-    );
-
-    await NearBridge.addLightClientBlock(block121498);
-    expect(await NearBridge.checkBlockProducerSignatureInHead(0)).to.be.true;
-
-    await expect(NearBridge.addLightClientBlock(block121998)).to.be.revertedWith('Epoch id of the block is not valid');
-    await increaseTime(3600);
-    expect(await NearBridge.blockHashes(121498)).to.be.equal(
-        '0x508307e7af9bdbb297afa7af0541130eb32f0f028151319f5a4f7ae68b0ecc56',
-    );
-
-    await NearBridge.addLightClientBlock(block121998);
-    expect(await NearBridge.checkBlockProducerSignatureInHead(0)).to.be.true;
-
-    await increaseTime(3600);
-    expect(await NearBridge.blockHashes(121998)).to.be.equal(
-        '0x2358c4881bbd111d2e4352b6a7e6c7595fb39d3c9897d3c624006be1ef809abf',
-    );
-});
+//it('should be ok', async function () {
+//    const block120998 = borshify(require('./block_120998.json'));
+//    const block121498 = borshify(require('./block_121498.json'));
+//    const block121998 = borshify(require('./block_121998.json'));
+//
+//    // We should use previous epoch's next_bps to initWithBlock with block_120998, but they happens to be same
+//    await NearBridge.initWithValidators(borshifyInitialValidators(require('./block_120998.json').next_bps));
+//    await NearBridge.initWithBlock(block120998);
+//    expect(await NearBridge.blockHashes(120998)).to.be.equal(
+//        '0x1a7a07b5eee1f4d8d7e47864d533143972f858464bacdc698774d167fb1b40e6',
+//    );
+//
+//    await NearBridge.addLightClientBlock(block121498);
+//    expect(await NearBridge.checkBlockProducerSignatureInHead(0)).to.be.true;
+//
+//    await expect(NearBridge.addLightClientBlock(block121998)).to.be.revertedWith('Epoch id of the block is not valid');
+//    await increaseTime(3600);
+//    expect(await NearBridge.blockHashes(121498)).to.be.equal(
+//        '0x508307e7af9bdbb297afa7af0541130eb32f0f028151319f5a4f7ae68b0ecc56',
+//    );
+//
+//    await NearBridge.addLightClientBlock(block121998);
+//    expect(await NearBridge.checkBlockProducerSignatureInHead(0)).to.be.true;
+//
+//    await increaseTime(3600);
+//    expect(await NearBridge.blockHashes(121998)).to.be.equal(
+//        '0x2358c4881bbd111d2e4352b6a7e6c7595fb39d3c9897d3c624006be1ef809abf',
+//    );
+//});
 
 if (process.env.NEAR_HEADERS_DIR) {
     it('ok with many block headers', async function () {

--- a/contracts/eth/nearbridge/test/NearBridge.js
+++ b/contracts/eth/nearbridge/test/NearBridge.js
@@ -53,37 +53,37 @@ beforeEach(async function () {
 //    );
 //});
 
-if (process.env.NEAR_HEADERS_DIR) {
-    it('ok with many block headers', async function () {
-        this.timeout(0);
-        const blockFiles = await fs.readdir(process.env.NEAR_HEADERS_DIR);
-        blockFiles.sort((a, b) => a.split('.')[0] - b.split('.')[0]);
-        const firstBlock = require(process.env.NEAR_HEADERS_DIR + '/' + blockFiles[0]);
-        const firstBlockBorsh = borshify(firstBlock);
-        // current bps happens to equal to next_bps
-        await NearBridge.initWithValidators(borshifyInitialValidators(firstBlock.next_bps));
-        await NearBridge.initWithBlock(firstBlockBorsh);
-        await NearBridge.blockHashes(firstBlock.inner_lite.height);
-        expect(await NearBridge.blockHashes(firstBlock.inner_lite.height)).to.be.a('string');
-
-        for (let i = 1; i < blockFiles.length; i++) {
-            const block = require(process.env.NEAR_HEADERS_DIR + '/' + blockFiles[i]);
-            const blockBorsh = borshify(block);
-            console.log('adding block ' + block.inner_lite.height);
-            await NearBridge.addLightClientBlock(blockBorsh);
-            await NearBridge.blockHashes(block.inner_lite.height);
-            await increaseTime(3600);
-
-            if (i >= 600) {
-                console.log('checking block ' + block.inner_lite.height);
-                for (let j = 0; j < block.approvals_after_next.length; j++) {
-                    console.log('checking approval ' + j);
-                    if (block.approvals_after_next[j]) {
-                        console.log('approval ' + j + ' is not null');
-                        expect(await NearBridge.checkBlockProducerSignatureInHead(j)).to.be.true;
-                    }
-                }
-            }
-        }
-    });
-}
+//if (process.env.NEAR_HEADERS_DIR) {
+//    it('ok with many block headers', async function () {
+//        this.timeout(0);
+//        const blockFiles = await fs.readdir(process.env.NEAR_HEADERS_DIR);
+//        blockFiles.sort((a, b) => a.split('.')[0] - b.split('.')[0]);
+//        const firstBlock = require(process.env.NEAR_HEADERS_DIR + '/' + blockFiles[0]);
+//        const firstBlockBorsh = borshify(firstBlock);
+//        // current bps happens to equal to next_bps
+//        await NearBridge.initWithValidators(borshifyInitialValidators(firstBlock.next_bps));
+//        await NearBridge.initWithBlock(firstBlockBorsh);
+//        await NearBridge.blockHashes(firstBlock.inner_lite.height);
+//        expect(await NearBridge.blockHashes(firstBlock.inner_lite.height)).to.be.a('string');
+//
+//        for (let i = 1; i < blockFiles.length; i++) {
+//            const block = require(process.env.NEAR_HEADERS_DIR + '/' + blockFiles[i]);
+//            const blockBorsh = borshify(block);
+//            console.log('adding block ' + block.inner_lite.height);
+//            await NearBridge.addLightClientBlock(blockBorsh);
+//            await NearBridge.blockHashes(block.inner_lite.height);
+//            await increaseTime(3600);
+//
+//            if (i >= 600) {
+//                console.log('checking block ' + block.inner_lite.height);
+//                for (let j = 0; j < block.approvals_after_next.length; j++) {
+//                    console.log('checking approval ' + j);
+//                    if (block.approvals_after_next[j]) {
+//                        console.log('approval ' + j + ' is not null');
+//                        expect(await NearBridge.checkBlockProducerSignatureInHead(j)).to.be.true;
+//                    }
+//                }
+//            }
+//        }
+//    });
+//}

--- a/contracts/eth/nearbridge/test/NearBridge2.js
+++ b/contracts/eth/nearbridge/test/NearBridge2.js
@@ -43,21 +43,21 @@ it('should be ok', async function () {
 
 });
 
-it('2020-09-09 Example', async function () {
-   const block_15178713 = borshify(require('./block_15178713.json'));
-   const block_15178760 = borshify(require('./block_15178760.json'));
-   const block_15204402 = borshify(require('./block_15204402.json'));
-   const block_15248583 = borshify(require('./block_15248583.json'));
-
-   await NearBridge.initWithValidators(borshifyInitialValidators(require('./init_validators_15178713.json')));
-   await NearBridge.initWithBlock(block_15178713);
-   await increaseTime(3600);
-   await NearBridge.addLightClientBlock(block_15178760);
-   await increaseTime(3600);
-   await NearBridge.addLightClientBlock(block_15204402);
-   await increaseTime(3600);
-   await NearBridge.addLightClientBlock(block_15248583);
-});
+//it('2020-09-09 Example', async function () {
+//   const block_15178713 = borshify(require('./block_15178713.json'));
+//   const block_15178760 = borshify(require('./block_15178760.json'));
+//   const block_15204402 = borshify(require('./block_15204402.json'));
+//   const block_15248583 = borshify(require('./block_15248583.json'));
+//
+//   await NearBridge.initWithValidators(borshifyInitialValidators(require('./init_validators_15178713.json')));
+//   await NearBridge.initWithBlock(block_15178713);
+//   await increaseTime(3600);
+//   await NearBridge.addLightClientBlock(block_15178760);
+//   await increaseTime(3600);
+//   await NearBridge.addLightClientBlock(block_15204402);
+//   await increaseTime(3600);
+//   await NearBridge.addLightClientBlock(block_15248583);
+//});
 
 it('Add second block in first epoch should be verifiable', async function () {
     // Get "initial validators" that will produce block 304
@@ -83,65 +83,65 @@ it('Add second block in first epoch should be verifiable', async function () {
     }
 });
 
-it('Test adding blocks in new epoch when bps change', async function () {
-    const block181 = require('./181.json');
-    const block244 = require('./244.json');
-    const block304 = require('./304.json');
-    const block308 = require('./308.json');
-    const block368 = require('./368.json');
-    const block369 = require('./369.json');
-
-    await NearBridge.initWithValidators(borshifyInitialValidators(block181.next_bps));
-    await NearBridge.initWithBlock(borshify(block244));
-    await NearBridge.blockHashes(244);
-
-    await increaseTime(3600);
-
-    await NearBridge.addLightClientBlock(borshify(block304));
-    await NearBridge.blockHashes(304);
-
-    await increaseTime(3600);
-
-    await NearBridge.addLightClientBlock(borshify(block308));
-    await NearBridge.blockHashes(308);
-
-    await increaseTime(3600);
-
-    await NearBridge.addLightClientBlock(borshify(block368));
-    await NearBridge.blockHashes(368);
-
-    await increaseTime(3600);
-
-    await NearBridge.addLightClientBlock(borshify(block369));
-    await NearBridge.blockHashes(369);
-});
-
-it('After challenge prev should be revert to prev epoch of latest valid block', async function () {
-    const block181 = require('./181.json');
-    const block244 = require('./244.json');
-    const block304 = require('./304.json');
-    const block308 = require('./308.json');
-    const block368 = require('./368.json');
-
-    await NearBridge.initWithValidators(borshifyInitialValidators(block181.next_bps));
-    await NearBridge.initWithBlock(borshify(block244));
-    await NearBridge.blockHashes(244);
-
-    await increaseTime(3600);
-    await NearBridge.addLightClientBlock(borshify(block304));
-    await NearBridge.blockHashes(304);
-
-    await increaseTime(3600);
-    await NearBridge.addLightClientBlock(borshify(block308));
-    await NearBridge.blockHashes(308);
-
-    await increaseTime(3600);
-
-    block368.approvals_after_next[0] = block368.approvals_after_next[1];
-    await NearBridge.addLightClientBlock(borshify(block368));
-    await NearBridge.blockHashes(368);
-    expect((await NearBridge.lastValidAt())).to.not.be.equal(0);
-
-    await NearBridge.challenge(ethers.constants.AddressZero, 0)
-    expect((await NearBridge.lastValidAt())).to.be.equal(0);
-});
+//it('Test adding blocks in new epoch when bps change', async function () {
+//    const block181 = require('./181.json');
+//    const block244 = require('./244.json');
+//    const block304 = require('./304.json');
+//    const block308 = require('./308.json');
+//    const block368 = require('./368.json');
+//    const block369 = require('./369.json');
+//
+//    await NearBridge.initWithValidators(borshifyInitialValidators(block181.next_bps));
+//    await NearBridge.initWithBlock(borshify(block244));
+//    await NearBridge.blockHashes(244);
+//
+//    await increaseTime(3600);
+//
+//    await NearBridge.addLightClientBlock(borshify(block304));
+//    await NearBridge.blockHashes(304);
+//
+//    await increaseTime(3600);
+//
+//    await NearBridge.addLightClientBlock(borshify(block308));
+//    await NearBridge.blockHashes(308);
+//
+//    await increaseTime(3600);
+//
+//    await NearBridge.addLightClientBlock(borshify(block368));
+//    await NearBridge.blockHashes(368);
+//
+//    await increaseTime(3600);
+//
+//    await NearBridge.addLightClientBlock(borshify(block369));
+//    await NearBridge.blockHashes(369);
+//});
+//
+//it('After challenge prev should be revert to prev epoch of latest valid block', async function () {
+//    const block181 = require('./181.json');
+//    const block244 = require('./244.json');
+//    const block304 = require('./304.json');
+//    const block308 = require('./308.json');
+//    const block368 = require('./368.json');
+//
+//    await NearBridge.initWithValidators(borshifyInitialValidators(block181.next_bps));
+//    await NearBridge.initWithBlock(borshify(block244));
+//    await NearBridge.blockHashes(244);
+//
+//    await increaseTime(3600);
+//    await NearBridge.addLightClientBlock(borshify(block304));
+//    await NearBridge.blockHashes(304);
+//
+//    await increaseTime(3600);
+//    await NearBridge.addLightClientBlock(borshify(block308));
+//    await NearBridge.blockHashes(308);
+//
+//    await increaseTime(3600);
+//
+//    block368.approvals_after_next[0] = block368.approvals_after_next[1];
+//    await NearBridge.addLightClientBlock(borshify(block368));
+//    await NearBridge.blockHashes(368);
+//    expect((await NearBridge.lastValidAt())).to.not.be.equal(0);
+//
+//    await NearBridge.challenge(ethers.constants.AddressZero, 0)
+//    expect((await NearBridge.lastValidAt())).to.be.equal(0);
+//});

--- a/contracts/eth/nearbridge/test/NearBridge2.js
+++ b/contracts/eth/nearbridge/test/NearBridge2.js
@@ -43,21 +43,24 @@ it('should be ok', async function () {
 
 });
 
-//it('2020-09-09 Example', async function () {
-//   const block_15178713 = borshify(require('./block_15178713.json'));
-//   const block_15178760 = borshify(require('./block_15178760.json'));
-//   const block_15204402 = borshify(require('./block_15204402.json'));
-//   const block_15248583 = borshify(require('./block_15248583.json'));
-//
-//   await NearBridge.initWithValidators(borshifyInitialValidators(require('./init_validators_15178713.json')));
-//   await NearBridge.initWithBlock(block_15178713);
-//   await increaseTime(3600);
-//   await NearBridge.addLightClientBlock(block_15178760);
-//   await increaseTime(3600);
-//   await NearBridge.addLightClientBlock(block_15204402);
-//   await increaseTime(3600);
-//   await NearBridge.addLightClientBlock(block_15248583);
-//});
+it('2020-09-09 Example', async function () {
+   // Skip until tests are upgraded having blocks after nearcore 1.23.0
+   this.skip();
+
+   const block_15178713 = borshify(require('./block_15178713.json'));
+   const block_15178760 = borshify(require('./block_15178760.json'));
+   const block_15204402 = borshify(require('./block_15204402.json'));
+   const block_15248583 = borshify(require('./block_15248583.json'));
+
+   await NearBridge.initWithValidators(borshifyInitialValidators(require('./init_validators_15178713.json')));
+   await NearBridge.initWithBlock(block_15178713);
+   await increaseTime(3600);
+   await NearBridge.addLightClientBlock(block_15178760);
+   await increaseTime(3600);
+   await NearBridge.addLightClientBlock(block_15204402);
+   await increaseTime(3600);
+   await NearBridge.addLightClientBlock(block_15248583);
+});
 
 it('Add second block in first epoch should be verifiable', async function () {
     // Get "initial validators" that will produce block 304
@@ -83,65 +86,71 @@ it('Add second block in first epoch should be verifiable', async function () {
     }
 });
 
-//it('Test adding blocks in new epoch when bps change', async function () {
-//    const block181 = require('./181.json');
-//    const block244 = require('./244.json');
-//    const block304 = require('./304.json');
-//    const block308 = require('./308.json');
-//    const block368 = require('./368.json');
-//    const block369 = require('./369.json');
-//
-//    await NearBridge.initWithValidators(borshifyInitialValidators(block181.next_bps));
-//    await NearBridge.initWithBlock(borshify(block244));
-//    await NearBridge.blockHashes(244);
-//
-//    await increaseTime(3600);
-//
-//    await NearBridge.addLightClientBlock(borshify(block304));
-//    await NearBridge.blockHashes(304);
-//
-//    await increaseTime(3600);
-//
-//    await NearBridge.addLightClientBlock(borshify(block308));
-//    await NearBridge.blockHashes(308);
-//
-//    await increaseTime(3600);
-//
-//    await NearBridge.addLightClientBlock(borshify(block368));
-//    await NearBridge.blockHashes(368);
-//
-//    await increaseTime(3600);
-//
-//    await NearBridge.addLightClientBlock(borshify(block369));
-//    await NearBridge.blockHashes(369);
-//});
-//
-//it('After challenge prev should be revert to prev epoch of latest valid block', async function () {
-//    const block181 = require('./181.json');
-//    const block244 = require('./244.json');
-//    const block304 = require('./304.json');
-//    const block308 = require('./308.json');
-//    const block368 = require('./368.json');
-//
-//    await NearBridge.initWithValidators(borshifyInitialValidators(block181.next_bps));
-//    await NearBridge.initWithBlock(borshify(block244));
-//    await NearBridge.blockHashes(244);
-//
-//    await increaseTime(3600);
-//    await NearBridge.addLightClientBlock(borshify(block304));
-//    await NearBridge.blockHashes(304);
-//
-//    await increaseTime(3600);
-//    await NearBridge.addLightClientBlock(borshify(block308));
-//    await NearBridge.blockHashes(308);
-//
-//    await increaseTime(3600);
-//
-//    block368.approvals_after_next[0] = block368.approvals_after_next[1];
-//    await NearBridge.addLightClientBlock(borshify(block368));
-//    await NearBridge.blockHashes(368);
-//    expect((await NearBridge.lastValidAt())).to.not.be.equal(0);
-//
-//    await NearBridge.challenge(ethers.constants.AddressZero, 0)
-//    expect((await NearBridge.lastValidAt())).to.be.equal(0);
-//});
+it('Test adding blocks in new epoch when bps change', async function () {
+    // Skip until tests are upgraded having blocks after nearcore 1.23.0
+    this.skip();
+
+    const block181 = require('./181.json');
+    const block244 = require('./244.json');
+    const block304 = require('./304.json');
+    const block308 = require('./308.json');
+    const block368 = require('./368.json');
+    const block369 = require('./369.json');
+
+    await NearBridge.initWithValidators(borshifyInitialValidators(block181.next_bps));
+    await NearBridge.initWithBlock(borshify(block244));
+    await NearBridge.blockHashes(244);
+
+    await increaseTime(3600);
+
+    await NearBridge.addLightClientBlock(borshify(block304));
+    await NearBridge.blockHashes(304);
+
+    await increaseTime(3600);
+
+    await NearBridge.addLightClientBlock(borshify(block308));
+    await NearBridge.blockHashes(308);
+
+    await increaseTime(3600);
+
+    await NearBridge.addLightClientBlock(borshify(block368));
+    await NearBridge.blockHashes(368);
+
+    await increaseTime(3600);
+
+    await NearBridge.addLightClientBlock(borshify(block369));
+    await NearBridge.blockHashes(369);
+});
+
+it('After challenge prev should be revert to prev epoch of latest valid block', async function () {
+    // Skip until tests are upgraded having blocks after nearcore 1.23.0
+    this.skip();
+
+    const block181 = require('./181.json');
+    const block244 = require('./244.json');
+    const block304 = require('./304.json');
+    const block308 = require('./308.json');
+    const block368 = require('./368.json');
+
+    await NearBridge.initWithValidators(borshifyInitialValidators(block181.next_bps));
+    await NearBridge.initWithBlock(borshify(block244));
+    await NearBridge.blockHashes(244);
+
+    await increaseTime(3600);
+    await NearBridge.addLightClientBlock(borshify(block304));
+    await NearBridge.blockHashes(304);
+
+    await increaseTime(3600);
+    await NearBridge.addLightClientBlock(borshify(block308));
+    await NearBridge.blockHashes(308);
+
+    await increaseTime(3600);
+
+    block368.approvals_after_next[0] = block368.approvals_after_next[1];
+    await NearBridge.addLightClientBlock(borshify(block368));
+    await NearBridge.blockHashes(368);
+    expect((await NearBridge.lastValidAt())).to.not.be.equal(0);
+
+    await NearBridge.challenge(ethers.constants.AddressZero, 0)
+    expect((await NearBridge.lastValidAt())).to.be.equal(0);
+});


### PR DESCRIPTION
I'd want to disable those tests as they are no longer used and working after nearcore 1.23.0 updated. The motivation for not removing those tests completely: when the new tests (updated ones) are added, it will be easier to review and verify that those will be actually the same tests but with different input data.