### PR TITLE
BSC: fix error `Header is already known`

### DIFF
--- a/eth2near/eth2near-block-relay/index.js
+++ b/eth2near/eth2near-block-relay/index.js
@@ -161,6 +161,18 @@ class Eth2NearRelay {
         }
       }
 
+      const isBlockAlreadySubmitted = async (chainBlock) => {
+        try {
+          const clientHashes = await this.ethClientContract.known_hashes(
+            chainBlock.number
+          )
+          return clientHashes.find((x) => x === chainBlock.hash)
+        } catch (e) {
+          console.error(e)
+          return await isBlockAlreadySubmitted(chainBlock)
+        }
+      }
+
       const estimatedValued = (previousBlockNumber === undefined) ? 0 : clientBlockNumber - (previousBlockNumber + this.totalSubmitBlock)
 
       /// In case there exist a fork, find how many steps should go backward (delta) to the first block
@@ -184,6 +196,12 @@ class Eth2NearRelay {
           for (let i = clientBlockNumber + 1; i <= endBlock; i++) {
             if (this.validateHeaderMode === 'bsc') {
               const block = await this.robustWeb3.getBlock(i)
+              if (await isBlockAlreadySubmitted(block)) {
+                if (endBlock <= chainBlockNumber) {
+                  endBlock++
+                  continue
+                }
+              }
               blockPromises.push({ header_rlp: block })
             } else {
               blockPromises.push(this.getParseBlock(i))
@@ -191,28 +209,29 @@ class Eth2NearRelay {
           }
 
           const blocks = await Promise.all(blockPromises)
+          const firstBlock = blocks[0].header_rlp
           console.log(
-            `Got and parsed block ${clientBlockNumber + 1} to block ${endBlock}`
+            `Got and parsed block ${firstBlock.number} to block ${endBlock}`
           )
 
           // Send all transactions in a single batch, so they are processed in order.
           const actions = []
-          for (let i = clientBlockNumber + 1, j = 0; i <= endBlock; i++, j++) {
-            const action = this.submitBlock(blocks[j], i)
+          for (const block of blocks) {
+            const action = this.submitBlock(block)
             actions.push(action)
           }
 
           const task = this.ethClientContract.account.signAndSendTransaction(this.ethClientContract.contractId, actions)
 
           console.log(
-            `Submit txn to add block ${clientBlockNumber + 1
+            `Submit txn to add block ${firstBlock.number
             } to block ${endBlock}`
           )
 
           await task
 
           console.log(
-            `Success added block ${clientBlockNumber + 1} to block ${endBlock}. Chain block number: ${chainBlockNumber}`
+            `Success added block ${firstBlock.number} to block ${endBlock}. Chain block number: ${chainBlockNumber}`
           )
         } catch (e) {
           errorsOnSubmitCounter.inc(1)
@@ -239,7 +258,7 @@ class Eth2NearRelay {
     }
   }
 
-  submitBlock (block, blockNumber) {
+  submitBlock (block) {
     let args
     if (this.validateHeaderMode === 'bsc') {
       args = {


### PR DESCRIPTION
The relayer uses `pub fn last_block_number` to get the last submitted block, but this logic doesn't work for BSC client because it returns the last final block and this led to getting the error `Header is already known. Number` on submitting blocks.
In this pull request, we check if the block has already been submitted before submitting it.