### PR TITLE
NEAR2Eth-Relay: Optimized Block Selection

### DIFF
--- a/cli/commands/danger-submit-invalid-near-block.js
+++ b/cli/commands/danger-submit-invalid-near-block.js
@@ -14,7 +14,9 @@ class DangerSubmitInvalidNearBlock {
     near2ethRelayMaxDelay,
     near2ethRelayErrorDelay,
     near2ethRelayBlockSelectDuration,
-    near2ethRelayAfterSubmitDelayMs
+    near2ethRelayNextBlockSelectDelayMs,
+    near2ethRelayAfterSubmitDelayMs,
+    logVerbose
   }) {
     const relay = new Near2EthRelay()
     await relay.initialize({
@@ -31,9 +33,11 @@ class DangerSubmitInvalidNearBlock {
       near2ethRelayMaxDelay,
       near2ethRelayErrorDelay,
       near2ethRelayBlockSelectDuration,
+      near2ethRelayNextBlockSelectDelayMs,
       near2ethRelayAfterSubmitDelayMs,
       ethGasMultiplier,
-      ethUseEip1559
+      ethUseEip1559,
+      logVerbose
     })
   }
 }

--- a/cli/commands/danger-submit-invalid-near-block.js
+++ b/cli/commands/danger-submit-invalid-near-block.js
@@ -9,9 +9,12 @@ class DangerSubmitInvalidNearBlock {
     ethClientArtifactPath,
     ethClientAddress,
     ethGasMultiplier,
+    ethUseEip1559,
     near2ethRelayMinDelay,
     near2ethRelayMaxDelay,
-    near2ethRelayErrorDelay
+    near2ethRelayErrorDelay,
+    near2ethRelayBlockSelectDuration,
+    near2ethRelayAfterSubmitDelayMs
   }) {
     const relay = new Near2EthRelay()
     await relay.initialize({
@@ -27,7 +30,10 @@ class DangerSubmitInvalidNearBlock {
       near2ethRelayMinDelay,
       near2ethRelayMaxDelay,
       near2ethRelayErrorDelay,
-      ethGasMultiplier
+      near2ethRelayBlockSelectDuration,
+      near2ethRelayAfterSubmitDelayMs,
+      ethGasMultiplier,
+      ethUseEip1559
     })
   }
 }

--- a/cli/commands/start/near2eth-relay.js
+++ b/cli/commands/start/near2eth-relay.js
@@ -17,7 +17,7 @@ class StartNear2EthRelayCommand {
     near2ethRelayMinDelay,
     near2ethRelayMaxDelay,
     near2ethRelayErrorDelay,
-    near2ethRelaySelectDuration,
+    near2ethRelayBlockSelectDuration,
     near2ethRelayAfterSubmitDelayMs,
     metricsPort
   }) {
@@ -48,7 +48,7 @@ class StartNear2EthRelayCommand {
             '--near2eth-relay-min-delay', near2ethRelayMinDelay,
             '--near2eth-relay-max-delay', near2ethRelayMaxDelay,
             '--near2eth-relay-error-delay', near2ethRelayErrorDelay,
-            '--near2eth-relay-select-duration', near2ethRelaySelectDuration,
+            '--near2eth-relay-block-select-duration', near2ethRelayBlockSelectDuration,
             '--near2eth-relay-after-submit-delay-ms', near2ethRelayAfterSubmitDelayMs,
             '--daemon', 'false',
             '--metrics-port', metricsPort
@@ -74,7 +74,7 @@ class StartNear2EthRelayCommand {
         near2ethRelayMinDelay,
         near2ethRelayMaxDelay,
         near2ethRelayErrorDelay,
-        near2ethRelaySelectDuration,
+        near2ethRelayBlockSelectDuration,
         near2ethRelayAfterSubmitDelayMs,
         ethGasMultiplier,
         ethUseEip1559

--- a/cli/commands/start/near2eth-relay.js
+++ b/cli/commands/start/near2eth-relay.js
@@ -13,6 +13,7 @@ class StartNear2EthRelayCommand {
     ethClientArtifactPath,
     ethClientAddress,
     ethGasMultiplier,
+    ethUseEip1559,
     near2ethRelayMinDelay,
     near2ethRelayMaxDelay,
     near2ethRelayErrorDelay,
@@ -42,6 +43,7 @@ class StartNear2EthRelayCommand {
             '--eth-client-artifact-path', ethClientArtifactPath,
             '--eth-client-address', ethClientAddress,
             '--eth-gas-multiplier', ethGasMultiplier,
+            '--eth-use-eip-1559', ethUseEip1559,
             '--near2eth-relay-min-delay', near2ethRelayMinDelay,
             '--near2eth-relay-max-delay', near2ethRelayMaxDelay,
             '--near2eth-relay-error-delay', near2ethRelayErrorDelay,
@@ -71,7 +73,8 @@ class StartNear2EthRelayCommand {
         near2ethRelayMaxDelay,
         near2ethRelayErrorDelay,
         near2ethRelaySelectDuration,
-        ethGasMultiplier
+        ethGasMultiplier,
+        ethUseEip1559
       })
     }
   }

--- a/cli/commands/start/near2eth-relay.js
+++ b/cli/commands/start/near2eth-relay.js
@@ -18,8 +18,10 @@ class StartNear2EthRelayCommand {
     near2ethRelayMaxDelay,
     near2ethRelayErrorDelay,
     near2ethRelayBlockSelectDuration,
+    near2ethRelayNextBlockSelectDelayMs,
     near2ethRelayAfterSubmitDelayMs,
-    metricsPort
+    metricsPort,
+    logVerbose
   }) {
     if (daemon === 'true') {
       ProcessManager.connect((err) => {
@@ -49,9 +51,11 @@ class StartNear2EthRelayCommand {
             '--near2eth-relay-max-delay', near2ethRelayMaxDelay,
             '--near2eth-relay-error-delay', near2ethRelayErrorDelay,
             '--near2eth-relay-block-select-duration', near2ethRelayBlockSelectDuration,
+            '--near2eth-relay-next-block-select-delay-ms', near2ethRelayNextBlockSelectDelayMs,
             '--near2eth-relay-after-submit-delay-ms', near2ethRelayAfterSubmitDelayMs,
             '--daemon', 'false',
-            '--metrics-port', metricsPort
+            '--metrics-port', metricsPort,
+            '--log-verbose', logVerbose
           ],
           wait_ready: true,
           kill_timeout: 60000,
@@ -75,9 +79,11 @@ class StartNear2EthRelayCommand {
         near2ethRelayMaxDelay,
         near2ethRelayErrorDelay,
         near2ethRelayBlockSelectDuration,
+        near2ethRelayNextBlockSelectDelayMs,
         near2ethRelayAfterSubmitDelayMs,
         ethGasMultiplier,
-        ethUseEip1559
+        ethUseEip1559,
+        logVerbose
       })
     }
   }

--- a/cli/commands/start/near2eth-relay.js
+++ b/cli/commands/start/near2eth-relay.js
@@ -16,6 +16,7 @@ class StartNear2EthRelayCommand {
     near2ethRelayMinDelay,
     near2ethRelayMaxDelay,
     near2ethRelayErrorDelay,
+    near2ethRelaySelectDuration,
     metricsPort
   }) {
     if (daemon === 'true') {
@@ -44,6 +45,7 @@ class StartNear2EthRelayCommand {
             '--near2eth-relay-min-delay', near2ethRelayMinDelay,
             '--near2eth-relay-max-delay', near2ethRelayMaxDelay,
             '--near2eth-relay-error-delay', near2ethRelayErrorDelay,
+            '--near2eth-relay-select-duration', near2ethRelaySelectDuration,
             '--daemon', 'false',
             '--metrics-port', metricsPort
           ],
@@ -68,6 +70,7 @@ class StartNear2EthRelayCommand {
         near2ethRelayMinDelay,
         near2ethRelayMaxDelay,
         near2ethRelayErrorDelay,
+        near2ethRelaySelectDuration,
         ethGasMultiplier
       })
     }

--- a/cli/index.js
+++ b/cli/index.js
@@ -883,7 +883,10 @@ RainbowConfig.addOptions(
     'near2eth-relay-min-delay',
     'near2eth-relay-max-delay',
     'near2eth-relay-error-delay',
-    'eth-gas-multiplier'
+    'near2eth-relay-block-select-duration',
+    'near2eth-relay-after-submit-delay-ms',
+    'eth-gas-multiplier',
+    'eth-use-eip-1559'
   ]
 )
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -157,6 +157,11 @@ RainbowConfig.declareOption(
   '1'
 )
 RainbowConfig.declareOption(
+  'eth-use-eip-1559',
+  'Allow submitting transactions using the EIP-1559 way.',
+  'false'
+)
+RainbowConfig.declareOption(
   'metrics-port',
   'On which port to expose metrics for corresponding relayer, if not provided no metrics exposed',
   null
@@ -372,6 +377,7 @@ RainbowConfig.addOptions(
     'near2eth-relay-error-delay',
     'near2eth-relay-select-duration',
     'eth-gas-multiplier',
+    'eth-use-eip-1559',
     'daemon',
     'metrics-port'
   ]

--- a/cli/index.js
+++ b/cli/index.js
@@ -278,6 +278,11 @@ RainbowConfig.declareOption(
   '1'
 )
 RainbowConfig.declareOption(
+  'near2eth-relay-select-duration',
+  'Number of seconds to select the optimal block to submit.',
+  '300'
+)
+RainbowConfig.declareOption(
   'watchdog-delay',
   'Number of seconds to wait after validating all signatures.',
   '300'
@@ -365,6 +370,7 @@ RainbowConfig.addOptions(
     'near2eth-relay-min-delay',
     'near2eth-relay-max-delay',
     'near2eth-relay-error-delay',
+    'near2eth-relay-select-duration',
     'eth-gas-multiplier',
     'daemon',
     'metrics-port'

--- a/cli/index.js
+++ b/cli/index.js
@@ -166,6 +166,11 @@ RainbowConfig.declareOption(
   'On which port to expose metrics for corresponding relayer, if not provided no metrics exposed',
   null
 )
+RainbowConfig.declareOption(
+  'log-verbose',
+  'Log more information than the standard logging process.',
+  'false'
+)
 
 // User-specific arguments.
 RainbowConfig.declareOption(
@@ -288,6 +293,11 @@ RainbowConfig.declareOption(
   '300'
 )
 RainbowConfig.declareOption(
+  'near2eth-relay-next-block-select-delay-ms',
+  'Number of ms until the next request in the optimal block selection algorithm.',
+  '1200'
+)
+RainbowConfig.declareOption(
   'near2eth-relay-after-submit-delay-ms',
   'Number of ms to wait after successfully submitting light client block to prevent submitting the same block again.',
   '240000'
@@ -381,11 +391,13 @@ RainbowConfig.addOptions(
     'near2eth-relay-max-delay',
     'near2eth-relay-error-delay',
     'near2eth-relay-block-select-duration',
+    'near2eth-relay-next-block-select-delay-ms',
     'near2eth-relay-after-submit-delay-ms',
     'eth-gas-multiplier',
     'eth-use-eip-1559',
     'daemon',
-    'metrics-port'
+    'metrics-port',
+    'log-verbose'
   ]
 )
 
@@ -884,9 +896,11 @@ RainbowConfig.addOptions(
     'near2eth-relay-max-delay',
     'near2eth-relay-error-delay',
     'near2eth-relay-block-select-duration',
+    'near2eth-relay-next-block-select-delay-ms',
     'near2eth-relay-after-submit-delay-ms',
     'eth-gas-multiplier',
-    'eth-use-eip-1559'
+    'eth-use-eip-1559',
+    'log-verbose'
   ]
 )
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -158,7 +158,7 @@ RainbowConfig.declareOption(
 )
 RainbowConfig.declareOption(
   'eth-use-eip-1559',
-  'Allow submitting transactions using the EIP-1559 way.',
+  'Allow submitting transactions using the EIP-1559 pricing mechanism.',
   'false'
 )
 RainbowConfig.declareOption(
@@ -283,7 +283,7 @@ RainbowConfig.declareOption(
   '1'
 )
 RainbowConfig.declareOption(
-  'near2eth-relay-select-duration',
+  'near2eth-relay-block-select-duration',
   'Number of seconds to select the optimal block to submit.',
   '300'
 )
@@ -380,7 +380,7 @@ RainbowConfig.addOptions(
     'near2eth-relay-min-delay',
     'near2eth-relay-max-delay',
     'near2eth-relay-error-delay',
-    'near2eth-relay-select-duration',
+    'near2eth-relay-block-select-duration',
     'near2eth-relay-after-submit-delay-ms',
     'eth-gas-multiplier',
     'eth-use-eip-1559',

--- a/docs/development.md
+++ b/docs/development.md
@@ -36,7 +36,7 @@ cli/index.js init-eth-ed25519 \
 ```
 Address of deployed contract: `0x5fbdb2315678afecb367f032d93f642f64180aa3`
 
-**NOTE:** The private key specified here is the key of the first account created by Hardhat and is publicly known.
+**NOTE:** The private key specified here is the key of the first account created by [Hardhat](https://hardhat.org/hardhat-network/#running-stand-alone-in-order-to-support-wallets-and-other-software) and is publicly known.
 
 Deploy and initialize EthClient contracts:
 ```bash
@@ -57,6 +57,7 @@ cli/index.js start near2eth-relay \
     --near-node-url https://rpc.testnet.near.org/ \
     --near-network-id testnet \
     --eth-client-address 0xe7f1725e7734ce288f8367e1bb143e90bb3f0512 \
+    --eth-use-eip-1559 true \
     --near2eth-relay-max-delay 10 \
     --near2eth-relay-select-duration 30 \
     --daemon false

--- a/docs/development.md
+++ b/docs/development.md
@@ -59,6 +59,7 @@ cli/index.js start near2eth-relay \
     --eth-client-address 0xe7f1725e7734ce288f8367e1bb143e90bb3f0512 \
     --eth-use-eip-1559 true \
     --near2eth-relay-max-delay 10 \
-    --near2eth-relay-select-duration 30 \
+    --near2eth-relay-block-select-duration 30 \
+    --near2eth-relay-after-submit-delay-ms 1000 \
     --daemon false
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,62 @@
+# Development
+
+The loosely coupled architecture of the Rainbow Bridge allows its parts to be developed independently of each other.
+This document describes the development workflow for each such component.
+
+## Preparation
+
+This assumes that supported versions of the `nvm`, `yarn`, `hardhat` are already installed.
+
+Switch to a supported `node` version and install dependencies:
+```bash
+nvm install 13
+yarn install
+```
+## Near2Eth Relay
+
+The service responsible for submitting the NEAR Light Client block  to Ethereum smart contracts.
+
+Compile Solidity contracts:
+```bash
+cd contracts/eth/nearbridge
+yarn install
+yarn build
+```
+
+Run local Hardhat node:
+```bash
+hardhat node
+```
+
+Deploy ED25519 Solidity contract:
+```bash
+cli/index.js init-eth-ed25519 \
+    --eth-node-url http://127.0.0.1:8545/ \
+    --eth-master-sk 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+```
+Address of deployed contract: `0x5fbdb2315678afecb367f032d93f642f64180aa3`
+
+**NOTE:** The private key specified here is the key of the first account created by Hardhat and is publicly known.
+
+Deploy and initialize EthClient contracts:
+```bash
+cli/index.js init-eth-client \
+    --eth-node-url http://127.0.0.1:8545/ \
+    --eth-master-sk 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
+    --eth-ed25519-address 0x5fbdb2315678afecb367f032d93f642f64180aa3 \
+    --eth-client-lock-duration 30 \
+    --eth-client-replace-duration 60
+```
+Address of deployed contract: `0xe7f1725e7734ce288f8367e1bb143e90bb3f0512`
+
+Start Near2EthRelay:
+```bash
+cli/index.js start near2eth-relay \
+    --eth-node-url http://127.0.0.1:8545/ \
+    --eth-master-sk 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
+    --near-node-url https://rpc.testnet.near.org/ \
+    --near-network-id testnet \
+    --eth-client-address 0xe7f1725e7734ce288f8367e1bb143e90bb3f0512 \
+    --near2eth-relay-max-delay 10 \
+    --daemon false
+```

--- a/docs/development.md
+++ b/docs/development.md
@@ -61,5 +61,6 @@ cli/index.js start near2eth-relay \
     --near2eth-relay-max-delay 10 \
     --near2eth-relay-block-select-duration 30 \
     --near2eth-relay-after-submit-delay-ms 1000 \
+    --log-verbose true \
     --daemon false
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -58,5 +58,6 @@ cli/index.js start near2eth-relay \
     --near-network-id testnet \
     --eth-client-address 0xe7f1725e7734ce288f8367e1bb143e90bb3f0512 \
     --near2eth-relay-max-delay 10 \
+    --near2eth-relay-select-duration 30 \
     --daemon false
 ```

--- a/near2eth/near2eth-block-relay/index.js
+++ b/near2eth/near2eth-block-relay/index.js
@@ -174,6 +174,7 @@ class Near2EthRelay {
     near2ethRelayMinDelay,
     near2ethRelayMaxDelay,
     near2ethRelayErrorDelay,
+    near2ethRelaySelectDuration,
     ethGasMultiplier
   }) {
     const clientContract = this.clientContract
@@ -186,10 +187,34 @@ class Near2EthRelay {
     const maxDelay = Number(near2ethRelayMaxDelay)
     const errorDelay = Number(near2ethRelayErrorDelay)
 
+    const selectDuration = web3.utils.toBN(Number(near2ethRelaySelectDuration) * 1000_000_000)
+
     const httpPrometheus = new HttpPrometheus(this.metricsPort, 'near_bridge_near2eth_')
     const clientHeightGauge = httpPrometheus.gauge('client_height', 'amount of block client processed')
     const chainHeightGauge = httpPrometheus.gauge('chain_height', 'current chain height')
 
+    let firstSeenBlockTimestamp = null
+    const nextBlockSelection = {
+      borshBlock: null,
+      height: 0,
+      set: function ({ borshBlock, lightClientBlock }) {
+        this.borshBlock = borshBlock
+        this.height = lightClientBlock.inner_lite.height
+        console.log(`The new optimal block is found. Height: ${this.height}. Size: ${this.borshBlock.length} bytes`)
+      },
+      clean: function () {
+        this.borshBlock = null
+        this.height = 0
+      },
+      isEmpty: function () {
+        return !this.borshBlock
+      },
+      isSuitable: function ({ borshBlock, lightClientBlock }) {
+        return !this.isEmpty() &&
+               this.height !== lightClientBlock.inner_lite.height &&
+               this.borshBlock.length >= borshBlock.length
+      }
+    }
     while (true) {
       try {
         // Determine the next action: sleep or attempt an update.
@@ -207,18 +232,54 @@ class Near2EthRelay {
           await clientContract.methods.replaceDuration().call()
         )
         const nextValidAt = web3.utils.toBN(bridgeState.nextValidAt)
-        let replaceDelay
+        let replaceDelay = web3.utils.toBN(0)
         if (!nextValidAt.isZero()) {
           replaceDelay = web3.utils
             .toBN(bridgeState.nextTimestamp)
             .add(replaceDuration)
             .sub(web3.utils.toBN(lastBlock.inner_lite.timestamp))
         }
+        firstSeenBlockTimestamp = firstSeenBlockTimestamp || lastBlock.inner_lite.timestamp
         // console.log({bridgeState, currentBlockHash, lastBlock, replaceDuration}) // DEBUG
         if (bridgeState.currentHeight < lastBlock.inner_lite.height) {
           if (nextValidAt.isZero() || replaceDelay.cmpn(0) <= 0) {
+            // Serialize once here to avoid multiple 'borshify(...)' function calls
+            const blockCouple = {
+              lightClientBlock: lastBlock,
+              borshBlock: borshify(lastBlock)
+            }
+
+            // Describe the selection logic here so as not to complicate the reading of the code
+            if (nextBlockSelection.isEmpty()) {
+              console.log('The selection of the optimal block has begun.')
+              nextBlockSelection.set(blockCouple)
+            } else if (nextBlockSelection.isSuitable(blockCouple)) {
+              nextBlockSelection.set(blockCouple)
+            }
+
+            // Calculation of selection delay starting from the first block seen after service restart
+            let selectDelay = selectDuration
+              .add(web3.utils.toBN(firstSeenBlockTimestamp))
+              .sub(web3.utils.toBN(lastBlock.inner_lite.timestamp))
+            if (!nextValidAt.isZero()) {
+              // Make sure that every time after restarting the service we have a delay for block selection
+              selectDelay = web3.utils.BN.max(
+                selectDelay,
+                selectDuration.add(replaceDelay)
+              )
+            }
+            if (selectDelay.cmpn(0) > 0) {
+              const selectDelaySeconds = selectDelay.div(web3.utils.toBN(1000_000_000))
+              console.log(`Last light client block: ${lastBlock.inner_lite.height}`)
+              console.log(`Time left to make a decision: ${selectDelaySeconds.toString()} seconds`)
+              await sleep(1000) // Block creation time is approximately one second, is an additional cli argument needed here?
+              continue
+            } else {
+              console.log('Time to make a decision is over!')
+            }
+
             console.log(
-              `Trying to submit new block at height ${lastBlock.inner_lite.height}.`
+              `Trying to submit new block at height ${nextBlockSelection.height}`
             )
 
             // Check whether master account has enough balance at stake.
@@ -242,17 +303,16 @@ class Near2EthRelay {
               console.log('Transferred.')
             }
 
-            const borshBlock = borshify(lastBlock)
             if (submitInvalidBlock) {
               console.log('Mutate block by one byte')
-              console.log(borshBlock)
-              borshBlock[Math.floor(borshBlock.length * Math.random())] += 1
+              console.log(nextBlockSelection.borshBlock)
+              nextBlockSelection.borshBlock[Math.floor(nextBlockSelection.borshBlock.length * Math.random())] += 1
             }
 
             const gasPrice = new BN(await web3.eth.getGasPrice())
             console.log('Gas price:', gasPrice.toNumber())
 
-            await clientContract.methods.addLightClientBlock(borshBlock).send({
+            await clientContract.methods.addLightClientBlock(nextBlockSelection.borshBlock).send({
               from: ethMasterAccount,
               gas: 10000000,
               handleRevert: true,
@@ -265,6 +325,7 @@ class Near2EthRelay {
             }
 
             console.log('Submitted.')
+            nextBlockSelection.clean()
             await sleep(240000) // To prevent submitting the same block again
             continue
           }

--- a/near2eth/near2eth-block-relay/index.js
+++ b/near2eth/near2eth-block-relay/index.js
@@ -174,7 +174,7 @@ class Near2EthRelay {
     near2ethRelayMinDelay,
     near2ethRelayMaxDelay,
     near2ethRelayErrorDelay,
-    near2ethRelaySelectDuration,
+    near2ethRelayBlockSelectDuration,
     near2ethRelayAfterSubmitDelayMs,
     ethGasMultiplier,
     ethUseEip1559
@@ -190,7 +190,7 @@ class Near2EthRelay {
     const errorDelay = Number(near2ethRelayErrorDelay)
     const afterSubmitDelayMs = Number(near2ethRelayAfterSubmitDelayMs)
 
-    const selectDuration = web3.utils.toBN(Number(near2ethRelaySelectDuration) * 1000_000_000)
+    const selectDuration = web3.utils.toBN(Number(near2ethRelayBlockSelectDuration) * 1000_000_000)
 
     ethGasMultiplier = Number(ethGasMultiplier)
     ethUseEip1559 = ethUseEip1559 === 'true'

--- a/testing/ci/e2e.sh
+++ b/testing/ci/e2e.sh
@@ -44,7 +44,7 @@ node index.js init-near-token-factory
 yarn run pm2 ping
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 40000
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 40000 --near2eth-relay-block-select-duration 5
 sleep 5
 yarn run pm2 list
 node index.js start eth2near-relay

--- a/testing/ci/e2e_deploy_contract.sh
+++ b/testing/ci/e2e_deploy_contract.sh
@@ -51,7 +51,7 @@ cat /tmp/eth2neartransfer.out | xargs node index.js deploy-token myerc20
 yarn run pm2 ping
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 40000
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 40000 --near2eth-relay-block-select-duration 5
 sleep 5
 yarn run pm2 list
 node index.js start eth2near-relay

--- a/testing/ci/e2e_deploy_contract.sh
+++ b/testing/ci/e2e_deploy_contract.sh
@@ -51,7 +51,7 @@ cat /tmp/eth2neartransfer.out | xargs node index.js deploy-token myerc20
 yarn run pm2 ping
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 40000 --near2eth-relay-block-select-duration 5
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 40000 --near2eth-relay-block-select-duration 0
 sleep 5
 yarn run pm2 list
 node index.js start eth2near-relay

--- a/testing/ci/test_challenge.sh
+++ b/testing/ci/test_challenge.sh
@@ -56,7 +56,7 @@ yarn run pm2 list
 
 sleep 30
 node index.js stop near2eth-relay
-node index.js DANGER submit_invalid_near_block
+node index.js DANGER submit_invalid_near_block --near2eth-relay-block-select-duration 5
 sleep 30
 node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 45000 --near2eth-relay-block-select-duration 5
 

--- a/testing/ci/test_challenge.sh
+++ b/testing/ci/test_challenge.sh
@@ -44,7 +44,7 @@ node index.js init-near-token-factory
 
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 45000 --near2eth-relay-block-select-duration 5 --eth-master-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 45000 --near2eth-relay-block-select-duration 0 --eth-master-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201
 sleep 5
 yarn run pm2 list
 node index.js start eth2near-relay
@@ -56,9 +56,9 @@ yarn run pm2 list
 
 sleep 30
 node index.js stop near2eth-relay
-node index.js DANGER submit_invalid_near_block --near2eth-relay-block-select-duration 5
+node index.js DANGER submit_invalid_near_block --near2eth-relay-block-select-duration 0
 sleep 30
-node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 45000 --near2eth-relay-block-select-duration 5
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 45000 --near2eth-relay-block-select-duration 0
 
 node index.js TESTING transfer-eth-erc20-to-near --amount 1000 \
 --eth-sender-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501200 \

--- a/testing/ci/test_challenge.sh
+++ b/testing/ci/test_challenge.sh
@@ -44,7 +44,7 @@ node index.js init-near-token-factory
 
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 45000 --eth-master-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 45000 --near2eth-relay-block-select-duration 5 --eth-master-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201
 sleep 5
 yarn run pm2 list
 node index.js start eth2near-relay
@@ -58,7 +58,7 @@ sleep 30
 node index.js stop near2eth-relay
 node index.js DANGER submit_invalid_near_block
 sleep 30
-node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 45000
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 45000 --near2eth-relay-block-select-duration 5
 
 node index.js TESTING transfer-eth-erc20-to-near --amount 1000 \
 --eth-sender-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501200 \

--- a/testing/ci/test_ethrelay_catchup.sh
+++ b/testing/ci/test_ethrelay_catchup.sh
@@ -46,7 +46,7 @@ node index.js init-near-token-factory
 yarn run pm2 ping
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 15000
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 15000 --near2eth-relay-block-select-duration 5
 sleep 5
 yarn run pm2 list
 sleep 100

--- a/utils/robust.js
+++ b/utils/robust.js
@@ -27,6 +27,49 @@ class RobustWeb3 {
   constructor (ethNodeUrl) {
     this.ethNodeUrl = ethNodeUrl
     this.web3 = new Web3(ethNodeUrl)
+
+    // The eth_maxPriorityFeePerGas method is not part of the Ethereum specification.
+    // This method was added by the Geth team and is not yet supported everywhere.
+    this.web3.extend({
+      property: 'extended',
+      methods: [{
+        name: 'maxPriorityFeePerGas',
+        call: 'eth_maxPriorityFeePerGas',
+        outputFormatter: this.web3.utils.hexToNumberString
+      }]
+    })
+  }
+
+  async maxPriorityFeePerGas () {
+    let value = '1500000000' // satisfactory default value
+    try {
+      // Providers such as Infura and Alchemy have implemented eth_maxPriorityFeePerGas,
+      // however not all pure eth clients or testing tools like Hardhat support it.
+      value = await this.web3.extended.maxPriorityFeePerGas()
+    } catch (e) {
+      console.warn('Fallback maxPriorityFeePerGas calculation.', e.toString())
+      const baseFeePerGas = (await this.getBlock('latest')).baseFeePerGas
+      const gasPrice = await this.web3.eth.getGasPrice()
+      value = this.web3.utils.toBN(gasPrice)
+        .sub(this.web3.utils.toBN(baseFeePerGas))
+        .toString()
+    }
+
+    return value
+  }
+
+  // Use the method name 'getFeeData' with similar functionality of ethers.js library
+  // https://docs.ethers.io/v5/api/providers/provider/#Provider-getFeeData
+  async getFeeData (multiplier = 1) {
+    const baseFeePerGas = this.web3.utils.toBN((await this.getBlock('latest')).baseFeePerGas)
+    const maxPriorityFeePerGas = this.web3.utils.toBN(await this.maxPriorityFeePerGas())
+      // Multiplying by an integer number can lead to overpayment, consider to implement a fee estimator
+      .mul(this.web3.utils.toBN(Math.max(1, multiplier)))
+    // Default: maxFeePerGas = maxPriorityFeePerGas + 2 * baseFeePerGas
+    const maxFeePerGas = this.web3.utils.toBN(2)
+      .mul(baseFeePerGas)
+      .add(maxPriorityFeePerGas)
+    return { baseFeePerGas, maxPriorityFeePerGas, maxFeePerGas }
   }
 
   async getBlockNumber () {

--- a/utils/robust.js
+++ b/utils/robust.js
@@ -46,8 +46,8 @@ class RobustWeb3 {
       // Providers such as Infura and Alchemy have implemented eth_maxPriorityFeePerGas,
       // however not all pure eth clients or testing tools like Hardhat support it.
       value = await this.web3.extended.maxPriorityFeePerGas()
-    } catch (e) {
-      console.warn('Fallback maxPriorityFeePerGas calculation.', e.toString())
+    } catch {
+      console.warn('Fallback maxPriorityFeePerGas calculation.')
       const baseFeePerGas = (await this.getBlock('latest')).baseFeePerGas
       const gasPrice = await this.web3.eth.getGasPrice()
       value = this.web3.utils.toBN(gasPrice)


### PR DESCRIPTION
### Summary:
- Added documentation for newcomers to get started developing NEAR2Eth-Relay.
- Added CLI argument `near2eth-relay-select-duration` that sets the number of seconds to select the optimal block to submit.
- Added CLI argument `eth-use-eip-1559` which allows submitting transactions using the EIP-1559 way.
- Added a state inside the main loop to hold the block during the optimal block selection algorithm.
- Implemented delay calculation for optimal block selection.
- RobustWeb3 is extended with `maxPriorityFeePerGas` and `getFeeData` methods.

Debugging was done locally on the Hardhat Network and remotely on the Rinkeby testnet. The results can be seen on Etherscan: [0xbabe69df0d9ca729a546fc2f8823660d3d641855](https://rinkeby.etherscan.io/address/0xbabe69df0d9ca729a546fc2f8823660d3d641855). The last few transactions were alternately formed with and without EIP-1559 for clarity.