### PR TITLE
Near2Eth-relay improvements. CI tests improvements

### DIFF
--- a/cli/commands/start/near2eth-relay.js
+++ b/cli/commands/start/near2eth-relay.js
@@ -16,6 +16,7 @@ class StartNear2EthRelayCommand {
     near2ethRelayMinDelay,
     near2ethRelayMaxDelay,
     near2ethRelayErrorDelay,
+    near2ethRelayAfterSubmitDelayMs,
     metricsPort
   }) {
     if (daemon === 'true') {
@@ -44,6 +45,7 @@ class StartNear2EthRelayCommand {
             '--near2eth-relay-min-delay', near2ethRelayMinDelay,
             '--near2eth-relay-max-delay', near2ethRelayMaxDelay,
             '--near2eth-relay-error-delay', near2ethRelayErrorDelay,
+            '--near2eth-relay-after-submit-delay-ms', near2ethRelayAfterSubmitDelayMs,
             '--daemon', 'false',
             '--metrics-port', metricsPort
           ],
@@ -68,6 +70,7 @@ class StartNear2EthRelayCommand {
         near2ethRelayMinDelay,
         near2ethRelayMaxDelay,
         near2ethRelayErrorDelay,
+        near2ethRelayAfterSubmitDelayMs,
         ethGasMultiplier
       })
     }

--- a/cli/index.js
+++ b/cli/index.js
@@ -278,6 +278,11 @@ RainbowConfig.declareOption(
   '1'
 )
 RainbowConfig.declareOption(
+  'near2eth-relay-after-submit-delay-ms',
+  'Number of ms to wait after successfully submitting light client block to prevent submitting the same block again.',
+  '240000'
+)
+RainbowConfig.declareOption(
   'watchdog-delay',
   'Number of seconds to wait after validating all signatures.',
   '300'
@@ -365,6 +370,7 @@ RainbowConfig.addOptions(
     'near2eth-relay-min-delay',
     'near2eth-relay-max-delay',
     'near2eth-relay-error-delay',
+    'near2eth-relay-after-submit-delay-ms',
     'eth-gas-multiplier',
     'daemon',
     'metrics-port'

--- a/near2eth/near2eth-block-relay/index.js
+++ b/near2eth/near2eth-block-relay/index.js
@@ -174,6 +174,7 @@ class Near2EthRelay {
     near2ethRelayMinDelay,
     near2ethRelayMaxDelay,
     near2ethRelayErrorDelay,
+    near2ethRelayAfterSubmitDelayMs,
     ethGasMultiplier
   }) {
     const clientContract = this.clientContract
@@ -185,6 +186,7 @@ class Near2EthRelay {
     const minDelay = Number(near2ethRelayMinDelay)
     const maxDelay = Number(near2ethRelayMaxDelay)
     const errorDelay = Number(near2ethRelayErrorDelay)
+    const afterSubmitDelayMs = Number(near2ethRelayAfterSubmitDelayMs)
 
     const httpPrometheus = new HttpPrometheus(this.metricsPort, 'near_bridge_near2eth_')
     const clientHeightGauge = httpPrometheus.gauge('client_height', 'amount of block client processed')
@@ -265,7 +267,7 @@ class Near2EthRelay {
             }
 
             console.log('Submitted.')
-            await sleep(240000) // To prevent submitting the same block again
+            await sleep(afterSubmitDelayMs) // To prevent submitting the same block again
             continue
           }
         }

--- a/testing/ci/e2e.sh
+++ b/testing/ci/e2e.sh
@@ -44,7 +44,7 @@ node index.js init-near-token-factory
 yarn run pm2 ping
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 65000
 sleep 5
 yarn run pm2 list
 node index.js start eth2near-relay

--- a/testing/ci/e2e.sh
+++ b/testing/ci/e2e.sh
@@ -44,7 +44,7 @@ node index.js init-near-token-factory
 yarn run pm2 ping
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay
+node index.js start near2eth-relay --near2eth-relay-max-delay 30
 sleep 5
 yarn run pm2 list
 node index.js start eth2near-relay

--- a/testing/ci/e2e.sh
+++ b/testing/ci/e2e.sh
@@ -35,7 +35,7 @@ yarn
 yarn build)
 node index.js init-eth-ed25519
 # Use short lockup time for tests
-node index.js init-eth-client --eth-client-lock-eth-amount 1000000000000000000 --eth-client-lock-duration 30
+node index.js init-eth-client --eth-client-lock-eth-amount 1000000000000000000 --eth-client-lock-duration 30 --eth-client-replace-duration 60
 node index.js init-eth-prover
 node index.js init-eth-erc20
 node index.js init-eth-locker
@@ -44,7 +44,7 @@ node index.js init-near-token-factory
 yarn run pm2 ping
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --near2eth-relay-max-delay 30
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30
 sleep 5
 yarn run pm2 list
 node index.js start eth2near-relay

--- a/testing/ci/e2e.sh
+++ b/testing/ci/e2e.sh
@@ -44,7 +44,7 @@ node index.js init-near-token-factory
 yarn run pm2 ping
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 65000
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 40000
 sleep 5
 yarn run pm2 list
 node index.js start eth2near-relay

--- a/testing/ci/e2e_deploy_contract.sh
+++ b/testing/ci/e2e_deploy_contract.sh
@@ -51,7 +51,7 @@ cat /tmp/eth2neartransfer.out | xargs node index.js deploy-token myerc20
 yarn run pm2 ping
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 65000
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 40000
 sleep 5
 yarn run pm2 list
 node index.js start eth2near-relay

--- a/testing/ci/e2e_deploy_contract.sh
+++ b/testing/ci/e2e_deploy_contract.sh
@@ -35,7 +35,7 @@ yarn
 yarn build)
 node index.js init-eth-ed25519
 # Use short lockup time for tests
-node index.js init-eth-client --eth-client-lock-eth-amount 1e18 --eth-client-lock-duration 30
+node index.js init-eth-client --eth-client-lock-eth-amount 1000000000000000000 --eth-client-lock-duration 30 --eth-client-replace-duration 60
 node index.js init-eth-prover
 node index.js init-eth-erc20
 node index.js init-eth-locker
@@ -51,7 +51,7 @@ cat /tmp/eth2neartransfer.out | xargs node index.js deploy-token myerc20
 yarn run pm2 ping
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30
 sleep 5
 yarn run pm2 list
 node index.js start eth2near-relay

--- a/testing/ci/e2e_deploy_contract.sh
+++ b/testing/ci/e2e_deploy_contract.sh
@@ -51,7 +51,7 @@ cat /tmp/eth2neartransfer.out | xargs node index.js deploy-token myerc20
 yarn run pm2 ping
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 65000
 sleep 5
 yarn run pm2 list
 node index.js start eth2near-relay

--- a/testing/ci/test_challenge.sh
+++ b/testing/ci/test_challenge.sh
@@ -44,7 +44,7 @@ node index.js init-near-token-factory
 
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 65000 --eth-master-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 45000 --eth-master-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201
 sleep 5
 yarn run pm2 list
 node index.js start eth2near-relay
@@ -58,7 +58,7 @@ sleep 30
 node index.js stop near2eth-relay
 node index.js DANGER submit_invalid_near_block
 sleep 30
-node index.js start near2eth-relay
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 45000
 
 node index.js TESTING transfer-eth-erc20-to-near --amount 1000 \
 --eth-sender-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501200 \

--- a/testing/ci/test_challenge.sh
+++ b/testing/ci/test_challenge.sh
@@ -36,7 +36,7 @@ yarn
 yarn build)
 node index.js init-eth-ed25519
 # Use short lockup time for tests
-node index.js init-eth-client --eth-client-lock-eth-amount 1000000000000000000 --eth-client-lock-duration 30
+node index.js init-eth-client --eth-client-lock-eth-amount 1000000000000000000 --eth-client-lock-duration 30 --eth-client-replace-duration 60
 node index.js init-eth-prover
 node index.js init-eth-erc20
 node index.js init-eth-locker
@@ -44,7 +44,7 @@ node index.js init-near-token-factory
 
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --eth-master-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --eth-master-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201
 sleep 5
 yarn run pm2 list
 node index.js start eth2near-relay

--- a/testing/ci/test_challenge.sh
+++ b/testing/ci/test_challenge.sh
@@ -44,7 +44,7 @@ node index.js init-near-token-factory
 
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --eth-master-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 65000 --eth-master-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201
 sleep 5
 yarn run pm2 list
 node index.js start eth2near-relay

--- a/testing/ci/test_ethrelay_catchup.sh
+++ b/testing/ci/test_ethrelay_catchup.sh
@@ -46,7 +46,7 @@ node index.js init-near-token-factory
 yarn run pm2 ping
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 25000
 sleep 5
 yarn run pm2 list
 sleep 100

--- a/testing/ci/test_ethrelay_catchup.sh
+++ b/testing/ci/test_ethrelay_catchup.sh
@@ -37,7 +37,7 @@ yarn
 yarn build)
 node index.js init-eth-ed25519
 # Use short lockup time for tests
-node index.js init-eth-client --eth-client-lock-eth-amount 1000000000000000000 --eth-client-lock-duration 10
+node index.js init-eth-client --eth-client-lock-eth-amount 1000000000000000000 --eth-client-lock-duration 10 --eth-client-replace-duration 20
 node index.js init-eth-prover
 node index.js init-eth-erc20
 node index.js init-eth-locker
@@ -46,7 +46,7 @@ node index.js init-near-token-factory
 yarn run pm2 ping
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30
 sleep 5
 yarn run pm2 list
 sleep 100

--- a/testing/ci/test_ethrelay_catchup.sh
+++ b/testing/ci/test_ethrelay_catchup.sh
@@ -46,7 +46,7 @@ node index.js init-near-token-factory
 yarn run pm2 ping
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 25000
+node index.js start near2eth-relay --near2eth-relay-min-delay 1 --near2eth-relay-max-delay 30 --near2eth-relay-after-submit-delay-ms 15000
 sleep 5
 yarn run pm2 list
 sleep 100


### PR DESCRIPTION
The purpose of this PR is to speed up CI tests which are unnecessarily slow. This was especially crucial for some complex tests (e.g. watchdog challenge test) which sometimes are timed out having usual parameters. After these changes tests are speeded up 4-10 times. 

Changes:
* Near2Eth-relay: added `near2eth-relay-after-submit-delay-ms` parameter.
* CI tests: specify reasonable block replace duration for `NearOnEthClient` which is aligned with the lock duration.
* CI tests: set lower value for `near2eth-relay-after-submit-delay-ms` parameter which is aligned with lock & replace duration values.
* CI tests: specify reasonable value for `near2eth-relay-max-delay`.
* CI tests: minor verbosity improvements.