### PR TITLE
AdminControlled: use `call` pattern to send ether

### DIFF
--- a/contracts/eth/nearbridge/contracts/AdminControlled.sol
+++ b/contracts/eth/nearbridge/contracts/AdminControlled.sol
@@ -70,7 +70,7 @@ contract AdminControlled {
     }
 
     function adminSendEth(address payable destination, uint amount) public onlyAdmin {
-        destination.transfer(amount);
+        destination.call{value: amount}("");
     }
 
     function adminReceiveEth() public payable onlyAdmin {}


### PR DESCRIPTION
Currently, `AdminControlled` contract uses `transfer()` method to transfer ether in `adminSendEth()` method. Even though this method is not utilized at the moment, it's recommended to change it for the future as `transfer()` gas provided might change.

* Use `.call{value: amount}("")` pattern to transfer ether.
* Reentrancy is being handled because the method is having `adminOnly` modifier.

Fixes #744