### PR TITLE
CI: fixes for `nearcore` v1.28.

### DIFF
--- a/cli/commands/start/near.js
+++ b/cli/commands/start/near.js
@@ -13,7 +13,7 @@ class StartLocalNearNodeCommand {
   static execute ({ archival }) {
     const neardPath = join(NEAR_BINARY_PATH, 'neard')
     const localnetPath = join(HOME, '/.near/localnet')
-    const initConfigCommand = `${neardPath} --home ${localnetPath} testnet  --v 1`
+    const initConfigCommand = `${neardPath} --home ${localnetPath} localnet  --v 1`
     const startNodeCommand = `nearup run localnet --num-nodes 1 --binary-path ${NEAR_BINARY_PATH}`
 
     request(getLocalNearNodeURL(), { json: true }, (err, _res, _body) => {


### PR DESCRIPTION
When `nearcore` v1.28 was recently introduced, we got some errors in CI. These were due to the removal of `testnet` alias for `testnet` option in `neard` command as was described in that [issue](https://github.com/near/nearcore/pull/7033).

This PR fixes to use `localnet` option instead of `testnet`.