### PR TITLE
Eth2-to-Near-relay: interaction with DAO

### DIFF
--- a/eth2near/contract_wrapper/src/contract_wrapper_trait.rs
+++ b/eth2near/contract_wrapper/src/contract_wrapper_trait.rs
@@ -1,7 +1,10 @@
+use near_primitives::types::AccountId;
 use near_primitives::views::FinalExecutionOutcomeView;
 use near_sdk::{Balance, Gas};
 
 pub trait ContractWrapper {
+    fn get_account_id(&self) -> AccountId;
+
     fn call_view_function(
         &self,
         method_name: String,

--- a/eth2near/contract_wrapper/src/dao_contract.rs
+++ b/eth2near/contract_wrapper/src/dao_contract.rs
@@ -48,6 +48,7 @@ impl DAOContract {
             json!({ "proposal": json!(proposal) })
                 .to_string()
                 .into_bytes(),
+
             Some(policy.proposal_bond.0),
             None,
         )?;

--- a/eth2near/contract_wrapper/src/dao_eth_client_contract.rs
+++ b/eth2near/contract_wrapper/src/dao_eth_client_contract.rs
@@ -1,0 +1,85 @@
+use crate::dao_contract::DAOContract;
+use crate::dao_types;
+use crate::eth_client_contract::EthClientContract;
+use crate::eth_client_contract_trait::EthClientContractTrait;
+use eth_types::eth2::{LightClientState, LightClientUpdate};
+use eth_types::{BlockHeader, H256};
+use near_primitives::hash::CryptoHash;
+use near_sdk::Balance;
+use std::error::Error;
+use std::str::FromStr;
+use std::thread;
+use std::time::Duration;
+use std::vec::Vec;
+
+pub struct DaoEthClientContract {
+    eth_client_contract: EthClientContract,
+    dao_contract: DAOContract,
+}
+
+impl DaoEthClientContract {
+    pub fn new(eth_client_contract: EthClientContract, dao_contract: DAOContract) -> Self {
+        Self {
+            eth_client_contract,
+            dao_contract,
+        }
+    }
+}
+
+impl EthClientContractTrait for DaoEthClientContract {
+    fn get_last_submitted_slot(&self) -> u64 {
+        self.eth_client_contract.get_last_submitted_slot()
+    }
+
+    fn is_known_block(&self, execution_block_hash: &H256) -> Result<bool, Box<dyn Error>> {
+        self.eth_client_contract
+            .is_known_block(execution_block_hash)
+    }
+
+    fn send_light_client_update(
+        &mut self,
+        light_client_update: LightClientUpdate,
+    ) -> Result<CryptoHash, Box<dyn Error>> {
+        let dao_trx_id = self.dao_contract.submit_light_client_update_proposal(
+            near_sdk::AccountId::from_str(&self.eth_client_contract.get_account_id().to_string())?,
+            light_client_update,
+        )?;
+        loop {
+            let proposal_status = self.dao_contract.get_proposal(dao_trx_id)?;
+            if proposal_status.proposal.status != dao_types::ProposalStatus::InProgress {
+                break;
+            }
+            thread::sleep(Duration::from_secs(10));
+        }
+
+        Ok(CryptoHash::default())
+    }
+
+    fn get_finalized_beacon_block_hash(&self) -> Result<H256, Box<dyn Error>> {
+        self.eth_client_contract.get_finalized_beacon_block_hash()
+    }
+
+    fn get_finalized_beacon_block_slot(&self) -> Result<u64, Box<dyn Error>> {
+        self.eth_client_contract.get_finalized_beacon_block_slot()
+    }
+
+    fn send_headers(
+        &mut self,
+        headers: &Vec<BlockHeader>,
+        end_slot: u64,
+    ) -> Result<CryptoHash, Box<dyn std::error::Error>> {
+        self.eth_client_contract.send_headers(headers, end_slot)
+    }
+
+    fn get_min_deposit(&self) -> Result<Balance, Box<dyn Error>> {
+        self.eth_client_contract.get_min_deposit()
+    }
+
+    fn register_submitter(&self) -> Result<CryptoHash, Box<dyn Error>> {
+        self.eth_client_contract.register_submitter()
+    }
+
+    fn get_light_client_state(&self) -> Result<LightClientState, Box<dyn Error>> {
+        self.eth_client_contract.get_light_client_state()
+    }
+}

--- a/eth2near/contract_wrapper/src/dao_eth_client_contract.rs
+++ b/eth2near/contract_wrapper/src/dao_eth_client_contract.rs
@@ -44,11 +44,15 @@ impl EthClientContractTrait for DaoEthClientContract {
             near_sdk::AccountId::from_str(&self.eth_client_contract.get_account_id().to_string())?,
             light_client_update,
         )?;
+
         loop {
-            let proposal_status = self.dao_contract.get_proposal(dao_trx_id)?;
-            if proposal_status.proposal.status != dao_types::ProposalStatus::InProgress {
-                break;
+            let proposal_status = self.dao_contract.get_proposal(dao_trx_id);
+            if let Ok(staus) = proposal_status {
+                if staus.proposal.status != dao_types::ProposalStatus::InProgress {
+                    break;
+                }
             }
+
             thread::sleep(Duration::from_secs(10));
         }
 

--- a/eth2near/contract_wrapper/src/dao_types.rs
+++ b/eth2near/contract_wrapper/src/dao_types.rs
@@ -60,7 +60,8 @@ pub struct PolicyParameters {
     pub bounty_forgiveness_period: Option<U64>,
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug)]
 #[serde(crate = "near_sdk::serde")]
 pub struct ProposalOutput {
     /// Id of the proposal.

--- a/eth2near/contract_wrapper/src/eth_client_contract.rs
+++ b/eth2near/contract_wrapper/src/eth_client_contract.rs
@@ -6,8 +6,8 @@ use eth_types::eth2::{
 };
 use eth_types::{BlockHeader, H256};
 use near_primitives::borsh::BorshSerialize;
-use near_primitives::hash::CryptoHash;
 use near_primitives::types::AccountId;
+use near_primitives::views::FinalExecutionOutcomeView;
 use near_sdk::Balance;
 use serde_json::json;
 use std::error::Error;
@@ -95,17 +95,13 @@ impl EthClientContractTrait for EthClientContract {
     fn send_light_client_update(
         &mut self,
         light_client_update: LightClientUpdate,
-    ) -> Result<CryptoHash, Box<dyn Error>> {
-        Ok(self
-            .contract_wrapper
-            .call_change_method(
-                "submit_beacon_chain_light_client_update".to_string(),
-                light_client_update.try_to_vec()?,
-                None,
-                None,
-            )?
-            .transaction
-            .hash)
+    ) -> Result<FinalExecutionOutcomeView, Box<dyn Error>> {
+        self.contract_wrapper.call_change_method(
+            "submit_beacon_chain_light_client_update".to_string(),
+            light_client_update.try_to_vec()?,
+            None,
+            None,
+        )
     }
 
     fn get_finalized_beacon_block_hash(&self) -> Result<H256, Box<dyn Error>> {
@@ -130,7 +126,7 @@ impl EthClientContractTrait for EthClientContract {
         &mut self,
         headers: &Vec<BlockHeader>,
         end_slot: u64,
-    ) -> Result<CryptoHash, Box<dyn std::error::Error>> {
+    ) -> Result<FinalExecutionOutcomeView, Box<dyn std::error::Error>> {
         self.last_slot = end_slot;
 
         let method_names = vec!["submit_execution_header".to_string(); headers.len()];
@@ -139,11 +135,8 @@ impl EthClientContractTrait for EthClientContract {
             .map(|header| header.try_to_vec().unwrap())
             .collect();
 
-        Ok(self
-            .contract_wrapper
-            .call_change_method_batch(method_names, args, None, None)?
-            .transaction
-            .hash)
+        self.contract_wrapper
+            .call_change_method_batch(method_names, args, None, None)
     }
 
     fn get_min_deposit(&self) -> Result<Balance, Box<dyn Error>> {
@@ -155,17 +148,13 @@ impl EthClientContractTrait for EthClientContract {
         )?)
     }
 
-    fn register_submitter(&self) -> Result<CryptoHash, Box<dyn Error>> {
-        Ok(self
-            .contract_wrapper
-            .call_change_method(
-                "register_submitter".to_string(),
-                json!({}).to_string().into_bytes(),
-                Some(self.get_min_deposit()?),
-                None,
-            )?
-            .transaction
-            .hash)
+    fn register_submitter(&self) -> Result<FinalExecutionOutcomeView, Box<dyn Error>> {
+        self.contract_wrapper.call_change_method(
+            "register_submitter".to_string(),
+            json!({}).to_string().into_bytes(),
+            Some(self.get_min_deposit()?),
+            None,
+        )
     }
 
     fn get_light_client_state(&self) -> Result<LightClientState, Box<dyn Error>> {

--- a/eth2near/contract_wrapper/src/eth_client_contract.rs
+++ b/eth2near/contract_wrapper/src/eth_client_contract.rs
@@ -1,4 +1,5 @@
 use crate::contract_wrapper_trait::ContractWrapper;
+use crate::eth_client_contract_trait::EthClientContractTrait;
 use borsh::BorshDeserialize;
 use eth_types::eth2::{
     ExtendedBeaconBlockHeader, LightClientState, LightClientUpdate, SyncCommittee,
@@ -25,103 +26,6 @@ impl EthClientContract {
             last_slot: 0,
             contract_wrapper,
         }
-    }
-
-    pub fn get_last_submitted_slot(&self) -> u64 {
-        return self.last_slot;
-    }
-
-    pub fn is_known_block(&self, execution_block_hash: &H256) -> Result<bool, Box<dyn Error>> {
-        let result = self.contract_wrapper.call_view_function(
-            "is_known_execution_header".to_string(),
-            execution_block_hash.try_to_vec()?,
-        )?;
-        let is_known: bool = bool::try_from_slice(&result)?;
-        Ok(is_known)
-    }
-
-    pub fn send_light_client_update(
-        &mut self,
-        light_client_update: LightClientUpdate,
-    ) -> Result<CryptoHash, Box<dyn Error>> {
-        Ok(self
-            .contract_wrapper
-            .call_change_method(
-                "submit_beacon_chain_light_client_update".to_string(),
-                light_client_update.try_to_vec()?,
-                None,
-                None,
-            )?
-            .transaction
-            .hash)
-    }
-
-    pub fn get_finalized_beacon_block_hash(&self) -> Result<H256, Box<dyn Error>> {
-        let result = self.contract_wrapper.call_view_function(
-            "finalized_beacon_block_root".to_string(),
-            json!({}).to_string().into_bytes(),
-        )?;
-        let beacon_block_hash: H256 = H256::try_from_slice(&result)?;
-        Ok(beacon_block_hash)
-    }
-
-    pub fn get_finalized_beacon_block_slot(&self) -> Result<u64, Box<dyn Error>> {
-        let result = self.contract_wrapper.call_view_function(
-            "finalized_beacon_block_slot".to_string(),
-            json!({}).to_string().into_bytes(),
-        )?;
-        let beacon_block_slot: u64 = u64::try_from_slice(&result)?;
-        Ok(beacon_block_slot)
-    }
-
-    pub fn send_headers(
-        &mut self,
-        headers: &Vec<BlockHeader>,
-        end_slot: u64,
-    ) -> Result<CryptoHash, Box<dyn std::error::Error>> {
-        self.last_slot = end_slot;
-
-        let method_names = vec!["submit_execution_header".to_string(); headers.len()];
-        let args = headers
-            .iter()
-            .map(|header| header.try_to_vec().unwrap())
-            .collect();
-
-        Ok(self
-            .contract_wrapper
-            .call_change_method_batch(method_names, args, None, None)?
-            .transaction
-            .hash)
-    }
-
-    pub fn get_min_deposit(&self) -> Result<Balance, Box<dyn Error>> {
-        Ok(Balance::try_from_slice(
-            &self.contract_wrapper.call_view_function(
-                "min_storage_balance_for_submitter".to_string(),
-                json!({}).to_string().into_bytes(),
-            )?,
-        )?)
-    }
-
-    pub fn register_submitter(&self) -> Result<CryptoHash, Box<dyn Error>> {
-        Ok(self
-            .contract_wrapper
-            .call_change_method(
-                "register_submitter".to_string(),
-                json!({}).to_string().into_bytes(),
-                Some(self.get_min_deposit()?),
-                None,
-            )?
-            .transaction
-            .hash)
-    }
-
-    pub fn get_light_client_state(&self) -> Result<LightClientState, Box<dyn Error>> {
-        let result = self
-            .contract_wrapper
-            .call_view_function("get_light_client_state".to_string(), vec![])?;
-
-        Ok(LightClientState::try_from_slice(result.as_slice())?)
     }
 
     pub fn init_contract(
@@ -167,5 +71,108 @@ impl EthClientContract {
                 None,
             )
             .unwrap();
+    }
+
+    pub fn get_account_id(&self) -> AccountId {
+        self.contract_wrapper.get_account_id()
+    }
+}
+
+impl EthClientContractTrait for EthClientContract {
+    fn get_last_submitted_slot(&self) -> u64 {
+        return self.last_slot;
+    }
+
+    fn is_known_block(&self, execution_block_hash: &H256) -> Result<bool, Box<dyn Error>> {
+        let result = self.contract_wrapper.call_view_function(
+            "is_known_execution_header".to_string(),
+            execution_block_hash.try_to_vec()?,
+        )?;
+        let is_known: bool = bool::try_from_slice(&result)?;
+        Ok(is_known)
+    }
+
+    fn send_light_client_update(
+        &mut self,
+        light_client_update: LightClientUpdate,
+    ) -> Result<CryptoHash, Box<dyn Error>> {
+        Ok(self
+            .contract_wrapper
+            .call_change_method(
+                "submit_beacon_chain_light_client_update".to_string(),
+                light_client_update.try_to_vec()?,
+                None,
+                None,
+            )?
+            .transaction
+            .hash)
+    }
+
+    fn get_finalized_beacon_block_hash(&self) -> Result<H256, Box<dyn Error>> {
+        let result = self.contract_wrapper.call_view_function(
+            "finalized_beacon_block_root".to_string(),
+            json!({}).to_string().into_bytes(),
+        )?;
+        let beacon_block_hash: H256 = H256::try_from_slice(&result)?;
+        Ok(beacon_block_hash)
+    }
+
+    fn get_finalized_beacon_block_slot(&self) -> Result<u64, Box<dyn Error>> {
+        let result = self.contract_wrapper.call_view_function(
+            "finalized_beacon_block_slot".to_string(),
+            json!({}).to_string().into_bytes(),
+        )?;
+        let beacon_block_slot: u64 = u64::try_from_slice(&result)?;
+        Ok(beacon_block_slot)
+    }
+
+    fn send_headers(
+        &mut self,
+        headers: &Vec<BlockHeader>,
+        end_slot: u64,
+    ) -> Result<CryptoHash, Box<dyn std::error::Error>> {
+        self.last_slot = end_slot;
+
+        let method_names = vec!["submit_execution_header".to_string(); headers.len()];
+        let args = headers
+            .iter()
+            .map(|header| header.try_to_vec().unwrap())
+            .collect();
+
+        Ok(self
+            .contract_wrapper
+            .call_change_method_batch(method_names, args, None, None)?
+            .transaction
+            .hash)
+    }
+
+    fn get_min_deposit(&self) -> Result<Balance, Box<dyn Error>> {
+        Ok(Balance::try_from_slice(
+            &self.contract_wrapper.call_view_function(
+                "min_storage_balance_for_submitter".to_string(),
+                json!({}).to_string().into_bytes(),
+            )?,
+        )?)
+    }
+
+    fn register_submitter(&self) -> Result<CryptoHash, Box<dyn Error>> {
+        Ok(self
+            .contract_wrapper
+            .call_change_method(
+                "register_submitter".to_string(),
+                json!({}).to_string().into_bytes(),
+                Some(self.get_min_deposit()?),
+                None,
+            )?
+            .transaction
+            .hash)
+    }
+
+    fn get_light_client_state(&self) -> Result<LightClientState, Box<dyn Error>> {
+        let result = self
+            .contract_wrapper
+            .call_view_function("get_light_client_state".to_string(), vec![])?;
+
+        Ok(LightClientState::try_from_slice(result.as_slice())?)
     }
 }

--- a/eth2near/contract_wrapper/src/eth_client_contract_trait.rs
+++ b/eth2near/contract_wrapper/src/eth_client_contract_trait.rs
@@ -1,6 +1,6 @@
 use eth_types::eth2::{LightClientState, LightClientUpdate};
 use eth_types::{BlockHeader, H256};
-use near_primitives::hash::CryptoHash;
+use near_primitives::views::FinalExecutionOutcomeView;
 use near_sdk::Balance;
 use std::error::Error;
 use std::vec::Vec;
@@ -11,7 +11,7 @@ pub trait EthClientContractTrait {
     fn send_light_client_update(
         &mut self,
         light_client_update: LightClientUpdate,
-    ) -> Result<CryptoHash, Box<dyn Error>>;
+    ) -> Result<FinalExecutionOutcomeView, Box<dyn Error>>;
 
     fn get_finalized_beacon_block_hash(&self) -> Result<H256, Box<dyn Error>>;
     fn get_finalized_beacon_block_slot(&self) -> Result<u64, Box<dyn Error>>;
@@ -19,9 +19,9 @@ pub trait EthClientContractTrait {
         &mut self,
         headers: &Vec<BlockHeader>,
         end_slot: u64,
-    ) -> Result<CryptoHash, Box<dyn std::error::Error>>;
+    ) -> Result<FinalExecutionOutcomeView, Box<dyn std::error::Error>>;
 
     fn get_min_deposit(&self) -> Result<Balance, Box<dyn Error>>;
-    fn register_submitter(&self) -> Result<CryptoHash, Box<dyn Error>>;
+    fn register_submitter(&self) -> Result<FinalExecutionOutcomeView, Box<dyn Error>>;
     fn get_light_client_state(&self) -> Result<LightClientState, Box<dyn Error>>;
 }

--- a/eth2near/contract_wrapper/src/eth_client_contract_trait.rs
+++ b/eth2near/contract_wrapper/src/eth_client_contract_trait.rs
@@ -1,0 +1,27 @@
+use eth_types::eth2::{LightClientState, LightClientUpdate};
+use eth_types::{BlockHeader, H256};
+use near_primitives::hash::CryptoHash;
+use near_sdk::Balance;
+use std::error::Error;
+use std::vec::Vec;
+
+pub trait EthClientContractTrait {
+    fn get_last_submitted_slot(&self) -> u64;
+    fn is_known_block(&self, execution_block_hash: &H256) -> Result<bool, Box<dyn Error>>;
+    fn send_light_client_update(
+        &mut self,
+        light_client_update: LightClientUpdate,
+    ) -> Result<CryptoHash, Box<dyn Error>>;
+
+    fn get_finalized_beacon_block_hash(&self) -> Result<H256, Box<dyn Error>>;
+    fn get_finalized_beacon_block_slot(&self) -> Result<u64, Box<dyn Error>>;
+    fn send_headers(
+        &mut self,
+        headers: &Vec<BlockHeader>,
+        end_slot: u64,
+    ) -> Result<CryptoHash, Box<dyn std::error::Error>>;
+
+    fn get_min_deposit(&self) -> Result<Balance, Box<dyn Error>>;
+    fn register_submitter(&self) -> Result<CryptoHash, Box<dyn Error>>;
+    fn get_light_client_state(&self) -> Result<LightClientState, Box<dyn Error>>;
+}

--- a/eth2near/contract_wrapper/src/lib.rs
+++ b/eth2near/contract_wrapper/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod contract_wrapper_trait;
 pub mod dao_contract;
+pub mod dao_eth_client_contract;
 pub mod dao_types;
 pub mod eth_client_contract;
+pub mod eth_client_contract_trait;
 pub mod near_contract_wrapper;

--- a/eth2near/contract_wrapper/src/near_contract_wrapper.rs
+++ b/eth2near/contract_wrapper/src/near_contract_wrapper.rs
@@ -143,4 +143,8 @@ impl ContractWrapper for NearContractWrapper {
             gas,
         )
     }
+
+    fn get_account_id(&self) -> AccountId {
+        self.contract_account.clone()
+    }
 }

--- a/eth2near/eth2near-block-relay-rs/src/config.rs
+++ b/eth2near/eth2near-block-relay-rs/src/config.rs
@@ -28,7 +28,7 @@ pub struct Config {
     // The Ethereum network name (main, kiln)
     pub network: String,
 
-    // Contract type (near, dao, file)
+    // Contract type (near, dao)
     pub contract_type: String,
 
     // Frequency of submission light client updates. Once in N epochs.

--- a/eth2near/eth2near-block-relay-rs/src/config.rs
+++ b/eth2near/eth2near-block-relay-rs/src/config.rs
@@ -39,6 +39,9 @@ pub struct Config {
 
     // NEAR network name (mainnet, testnet)
     pub near_network_id: String,
+
+    // Account id for DAO on NEAR
+    pub dao_contract_account_id: Option<String>,
 }
 
 impl Config {

--- a/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
+++ b/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
@@ -3,8 +3,7 @@ use crate::config::Config;
 use crate::eth1_rpc_client::Eth1RPCClient;
 use crate::hand_made_finality_light_client_update::HandMadeFinalityLightClientUpdate;
 use crate::relay_errors::{ExecutionPayloadError, MissSyncCommitteeUpdate};
-use contract_wrapper::contract_wrapper_trait::ContractWrapper;
-use contract_wrapper::eth_client_contract::EthClientContract;
+use contract_wrapper::eth_client_contract_trait::EthClientContractTrait;
 use eth_types::eth2::LightClientUpdate;
 use eth_types::{BlockHeader, H256};
 use log::{debug, info, trace, warn};
@@ -17,7 +16,7 @@ const ONE_EPOCH_IN_SLOTS: u64 = 32;
 pub struct Eth2NearRelay {
     beacon_rpc_client: BeaconRPCClient,
     eth1_rpc_client: Eth1RPCClient,
-    eth_client_contract: EthClientContract,
+    eth_client_contract: Box<dyn EthClientContractTrait>,
     max_submitted_headers: u64,
     current_gap_between_finalized_and_signature_slot: u64,
     network: String,
@@ -30,7 +29,7 @@ pub struct Eth2NearRelay {
 impl Eth2NearRelay {
     pub fn init(
         config: &Config,
-        contract_wrapper: Box<dyn ContractWrapper>,
+        eth_contract: Box<dyn EthClientContractTrait>,
         enable_binsearch: bool,
         register_relay: bool,
     ) -> Self {
@@ -39,7 +38,7 @@ impl Eth2NearRelay {
         let eth2near_relay = Eth2NearRelay {
             beacon_rpc_client: BeaconRPCClient::new(&config.beacon_endpoint),
             eth1_rpc_client: Eth1RPCClient::new(&config.eth1_endpoint),
-            eth_client_contract: EthClientContract::new(contract_wrapper),
+            eth_client_contract: eth_contract,
             max_submitted_headers: config.total_submit_headers as u64,
             current_gap_between_finalized_and_signature_slot:
                 Self::get_gap_between_finalized_and_signature_slot(

--- a/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
+++ b/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
@@ -128,8 +128,9 @@ impl Eth2NearRelay {
                         .eth_client_contract
                         .send_headers(&headers, current_slot - 1)
                     {
-                        Ok(transaction_id) => {
-                            info!(target: "relay", "Successful headers submission! Transaction URL: https://explorer.{}.near.org/transactions/{}", self.near_network_name, transaction_id);
+                        Ok(execution_outcome) => {
+                            info!(target: "relay", "Successful headers submission! Transaction URL: https://explorer.{}.near.org/transactions/{}", 
+                                  self.near_network_name, execution_outcome.transaction.hash);
                             break;
                         }
                         Err(err) => {
@@ -358,8 +359,9 @@ impl Eth2NearRelay {
                         .eth_client_contract
                         .send_light_client_update(light_client_update)
                     {
-                        Ok(transaction_id) => {
-                            info!(target: "relay", "Successful light client update submission! Transaction URL: https://explorer.{}.near.org/transactions/{}", self.near_network_name, transaction_id);
+                        Ok(execution_outcome) => {
+                            info!(target: "relay", "Successful light client update submission! Transaction URL: https://explorer.{}.near.org/transactions/{}", 
+                                  self.near_network_name, execution_outcome.transaction.hash);
                             self.current_gap_between_finalized_and_signature_slot =
                                 Self::get_gap_between_finalized_and_signature_slot(
                                     self.light_client_updates_submission_frequency_in_epochs as u64,

--- a/eth2near/eth2near-block-relay-rs/src/main.rs
+++ b/eth2near/eth2near-block-relay-rs/src/main.rs
@@ -2,7 +2,7 @@ extern crate core;
 
 use clap::{ArgAction, Parser};
 use contract_wrapper::contract_wrapper_trait::ContractWrapper;
-use contract_wrapper::eth_client_contract;
+use contract_wrapper::{dao_contract, dao_eth_client_contract, eth_client_contract};
 use contract_wrapper::near_contract_wrapper::NearContractWrapper;
 use eth2_to_near_relay::config::Config;
 use eth2_to_near_relay::eth2near_relay::Eth2NearRelay;
@@ -10,6 +10,7 @@ use eth2_to_near_relay::init_contract::init_contract;
 use eth2_to_near_relay::logger::SimpleLogger;
 use log::LevelFilter;
 use std::string::String;
+use contract_wrapper::eth_client_contract_trait::EthClientContractTrait;
 
 #[derive(Parser, Default, Debug)]
 #[clap(version, about = "Eth2 to Near Relay")]
@@ -35,20 +36,38 @@ struct Arguments {
     enable_binary_search: bool,
 }
 
-fn get_contract_wrapper(config: &Config) -> Box<dyn ContractWrapper> {
+fn get_eth_contract_wrapper(config: &Config) -> Box<dyn ContractWrapper> {
+    Box::new(NearContractWrapper::new(
+        &config.near_endpoint,
+        &config.signer_account_id,
+        &config.path_to_signer_secret_key,
+        &config.contract_account_id,
+    ))
+}
+
+fn get_dao_contract_wrapper(config: &Config) -> Box<dyn ContractWrapper> {
+    let dao_contract_account_id = config.dao_contract_account_id.clone();
+
+    Box::new(NearContractWrapper::new(
+        &config.near_endpoint,
+        &config.signer_account_id,
+        &config.path_to_signer_secret_key,
+        &dao_contract_account_id.unwrap(),
+    ))
+}
+
+fn get_eth_client_contract(config: &Config) -> Box<dyn EthClientContractTrait> {
+    let eth_contract_wrapper = get_eth_contract_wrapper(config);
+    let eth_client = eth_client_contract::EthClientContract::new(eth_contract_wrapper);
+
     match config.contract_type.as_str() {
-        "near" => Box::new(NearContractWrapper::new(
-            &config.near_endpoint,
-            &config.signer_account_id,
-            &config.path_to_signer_secret_key,
-            &config.contract_account_id,
-        )),
-        _ => Box::new(NearContractWrapper::new(
-            &config.near_endpoint,
-            &config.signer_account_id,
-            &config.path_to_signer_secret_key,
-            &config.contract_account_id,
-        )),
+        "dao" => {
+            Box::new(dao_eth_client_contract::DaoEthClientContract::new(
+                eth_client,
+                dao_contract::DAOContract::new(get_dao_contract_wrapper(config))
+            ))
+        },
+        _ => Box::new(eth_client)
     }
 }
 
@@ -68,14 +87,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::load_from_toml(args.config.try_into().unwrap());
 
     if args.init_contract {
-        init_contract(&config, get_contract_wrapper(&config)).unwrap();
+        init_contract(&config, get_eth_contract_wrapper(&config)).unwrap();
     }
 
     let mut eth2near_relay = Eth2NearRelay::init(
         &config,
-        Box::new(eth_client_contract::EthClientContract::new(
-            get_contract_wrapper(&config),
-        )),
+        get_eth_client_contract(&config),
         args.enable_binary_search,
         args.register_relay,
     );

--- a/eth2near/eth2near-block-relay-rs/src/main.rs
+++ b/eth2near/eth2near-block-relay-rs/src/main.rs
@@ -2,15 +2,15 @@ extern crate core;
 
 use clap::{ArgAction, Parser};
 use contract_wrapper::contract_wrapper_trait::ContractWrapper;
-use contract_wrapper::{dao_contract, dao_eth_client_contract, eth_client_contract};
+use contract_wrapper::eth_client_contract_trait::EthClientContractTrait;
 use contract_wrapper::near_contract_wrapper::NearContractWrapper;
+use contract_wrapper::{dao_contract, dao_eth_client_contract, eth_client_contract};
 use eth2_to_near_relay::config::Config;
 use eth2_to_near_relay::eth2near_relay::Eth2NearRelay;
 use eth2_to_near_relay::init_contract::init_contract;
 use eth2_to_near_relay::logger::SimpleLogger;
 use log::LevelFilter;
 use std::string::String;
-use contract_wrapper::eth_client_contract_trait::EthClientContractTrait;
 
 #[derive(Parser, Default, Debug)]
 #[clap(version, about = "Eth2 to Near Relay")]
@@ -61,13 +61,11 @@ fn get_eth_client_contract(config: &Config) -> Box<dyn EthClientContractTrait> {
     let eth_client = eth_client_contract::EthClientContract::new(eth_contract_wrapper);
 
     match config.contract_type.as_str() {
-        "dao" => {
-            Box::new(dao_eth_client_contract::DaoEthClientContract::new(
-                eth_client,
-                dao_contract::DAOContract::new(get_dao_contract_wrapper(config))
-            ))
-        },
-        _ => Box::new(eth_client)
+        "dao" => Box::new(dao_eth_client_contract::DaoEthClientContract::new(
+            eth_client,
+            dao_contract::DAOContract::new(get_dao_contract_wrapper(config)),
+        )),
+        _ => Box::new(eth_client),
     }
 }
 

--- a/eth2near/eth2near-block-relay-rs/src/main.rs
+++ b/eth2near/eth2near-block-relay-rs/src/main.rs
@@ -2,6 +2,7 @@ extern crate core;
 
 use clap::{ArgAction, Parser};
 use contract_wrapper::contract_wrapper_trait::ContractWrapper;
+use contract_wrapper::eth_client_contract;
 use contract_wrapper::near_contract_wrapper::NearContractWrapper;
 use eth2_to_near_relay::config::Config;
 use eth2_to_near_relay::eth2near_relay::Eth2NearRelay;
@@ -72,7 +73,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut eth2near_relay = Eth2NearRelay::init(
         &config,
-        get_contract_wrapper(&config),
+        Box::new(eth_client_contract::EthClientContract::new(
+            get_contract_wrapper(&config),
+        )),
         args.enable_binary_search,
         args.register_relay,
     );


### PR DESCRIPTION
Implementation of Eth Client Wrapper for interaction with DAO.

We created a trait for Eth Client Wrapper with two implementations: (1) direct interaction with contract(eth_client_contract.rs), (2) submitting the light client updates by DAO (**dao_eth_client_contract.rs**).

In DAO ETH2 Client wrapper implementation, all functions except `send_light_client_update` work in the same way as in the classic implementation and call the correspondent functions in EthClientContract inside.  In `send_light_client_update` we submit the light client update to DAO and actively wait for when the transaction will be handled on DAO (until the status changes from `InProgress`).  
