### PR TITLE
Eth2-to-Near-relay: improvements and bugs fixes

### DIFF
--- a/eth2near/contract_wrapper/src/dao_eth_client_contract.rs
+++ b/eth2near/contract_wrapper/src/dao_eth_client_contract.rs
@@ -42,20 +42,22 @@ impl EthClientContractTrait for DaoEthClientContract {
     ) -> Result<FinalExecutionOutcomeView, Box<dyn Error>> {
         // Check for already submitted updates
         let last_proposal_id = self.dao_contract.get_last_proposal_id()?;
-        let last_proposal_output = self.dao_contract.get_proposal(last_proposal_id)?;
-        if last_proposal_output.proposal.status == dao_types::ProposalStatus::InProgress
-            && last_proposal_output.proposal.proposer.to_string()
-                == self
-                    .dao_contract
-                    .contract_wrapper
-                    .get_signer_account_id()
-                    .to_string()
-        {
-            return Err(format!(
-                "A proposal {} has already been submitted by this relayer which is in progress",
-                last_proposal_id
-            )
-            .into());
+        if last_proposal_id > 0 {
+            let last_proposal_output = self.dao_contract.get_proposal(last_proposal_id - 1)?;
+            if last_proposal_output.proposal.status == dao_types::ProposalStatus::InProgress
+                && last_proposal_output.proposal.proposer.to_string()
+                    == self
+                        .dao_contract
+                        .contract_wrapper
+                        .get_signer_account_id()
+                        .to_string()
+            {
+                return Err(format!(
+                    "A proposal {} has already been submitted by this relayer which is in progress",
+                    last_proposal_id
+                )
+                .into());
+            }
         }
 
         // Submmit new proposal

--- a/eth2near/contract_wrapper/src/errors.rs
+++ b/eth2near/contract_wrapper/src/errors.rs
@@ -1,0 +1,14 @@
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::error::Error;
+
+#[derive(Debug)]
+pub struct TryToSubmitZeroHeaderError;
+
+impl Display for TryToSubmitZeroHeaderError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Try to submit zero headers")
+    }
+}
+
+impl Error for TryToSubmitZeroHeaderError {}

--- a/eth2near/contract_wrapper/src/eth_client_contract.rs
+++ b/eth2near/contract_wrapper/src/eth_client_contract.rs
@@ -129,6 +129,10 @@ impl EthClientContractTrait for EthClientContract {
     ) -> Result<FinalExecutionOutcomeView, Box<dyn std::error::Error>> {
         self.last_slot = end_slot;
 
+        if headers.len() == 0 {
+            return Err(Box::new(crate::errors::TryToSubmitZeroHeaderError));
+        }
+
         let method_names = vec!["submit_execution_header".to_string(); headers.len()];
         let args = headers
             .iter()

--- a/eth2near/contract_wrapper/src/lib.rs
+++ b/eth2near/contract_wrapper/src/lib.rs
@@ -7,4 +7,4 @@ pub mod eth_client_contract_trait;
 pub mod file_eth_client_contract;
 pub mod near_contract_wrapper;
 pub mod sandbox_contract_wrapper;
-pub mod utils;
+pub mod errors;

--- a/eth2near/contract_wrapper/src/lib.rs
+++ b/eth2near/contract_wrapper/src/lib.rs
@@ -8,3 +8,4 @@ pub mod file_eth_client_contract;
 pub mod near_contract_wrapper;
 pub mod sandbox_contract_wrapper;
 pub mod errors;
+pub mod utils;

--- a/eth2near/contract_wrapper/src/near_contract_wrapper.rs
+++ b/eth2near/contract_wrapper/src/near_contract_wrapper.rs
@@ -12,8 +12,6 @@ use std::string::String;
 use std::vec::Vec;
 use tokio::runtime::Runtime;
 use crate::utils::trim_quotes;
-use tokio::task;
-use std::time::Duration;
 
 pub const MAX_GAS: Gas = Gas(Gas::ONE_TERA.0 * 300);
 

--- a/eth2near/contract_wrapper/src/near_contract_wrapper.rs
+++ b/eth2near/contract_wrapper/src/near_contract_wrapper.rs
@@ -12,6 +12,8 @@ use std::string::String;
 use std::vec::Vec;
 use tokio::runtime::Runtime;
 use crate::utils::trim_quotes;
+use tokio::task;
+use std::time::Duration;
 
 pub const MAX_GAS: Gas = Gas(Gas::ONE_TERA.0 * 300);
 
@@ -148,7 +150,10 @@ impl ContractWrapper for NearContractWrapper {
             signed_transaction: transaction.sign(&self.signer),
         };
 
-        Ok(rt.block_on(self.client.call(&request))?)
+        let request_result = rt.block_on(async_std::future::timeout(
+            std::time::Duration::from_secs(600),
+            self.client.call(&request)))?;
+        Ok(request_result?)
     }
 
     fn call_change_method(

--- a/eth2near/contract_wrapper/src/near_contract_wrapper.rs
+++ b/eth2near/contract_wrapper/src/near_contract_wrapper.rs
@@ -118,6 +118,11 @@ impl ContractWrapper for NearContractWrapper {
         };
 
         let num_blocks_in_batch = method_name.len() as u64;
+
+        if num_blocks_in_batch == 0 {
+            return Err(Box::new(crate::errors::TryToSubmitZeroHeaderError));
+        }
+
         let attached_gas_per_promise_in_batch = gas.unwrap_or(MAX_GAS) / num_blocks_in_batch;
         let mut actions = Vec::new();
 

--- a/eth2near/eth2near-block-relay-rs/Cargo.lock
+++ b/eth2near/eth2near-block-relay-rs/Cargo.lock
@@ -1163,6 +1163,7 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "atomic_refcell",
+ "bitvec 0.17.4",
  "borsh",
  "clap",
  "contract_wrapper",

--- a/eth2near/eth2near-block-relay-rs/Cargo.toml
+++ b/eth2near/eth2near-block-relay-rs/Cargo.toml
@@ -26,6 +26,7 @@ hex = "*"
 toml = "0.5.9"
 finality-update-verify = { path = "../finality-update-verify" }
 atomic_refcell = "0.1.8"
+bitvec = "*"
 
 near-jsonrpc-client = "0.4.0-beta.0"
 near-crypto = "0.14.0"

--- a/eth2near/eth2near-block-relay-rs/src/beacon_rpc_client.rs
+++ b/eth2near/eth2near-block-relay-rs/src/beacon_rpc_client.rs
@@ -43,15 +43,15 @@ impl BeaconRPCClient {
     const EPOCHS_PER_PERIOD: u64 = 256;
 
     /// Creates `BeaconRPCClient` for the given BeaconAPI `endpoint_url`
-    pub fn new(endpoint_url: &str, timeout: u64, timeout_state: u64) -> Self {
+    pub fn new(endpoint_url: &str, timeout_seconds: u64, timeout_state_seconds: u64) -> Self {
         Self {
             endpoint_url: endpoint_url.to_string(),
             client: reqwest::blocking::Client::builder()
-                .timeout(Duration::from_secs(timeout))
+                .timeout(Duration::from_secs(timeout_seconds))
                 .build()
                 .unwrap(),
             client_state_request: reqwest::blocking::Client::builder()
-                .timeout(Duration::from_secs(timeout_state))
+                .timeout(Duration::from_secs(timeout_state_seconds))
                 .build()
                 .unwrap(),
         }
@@ -476,8 +476,8 @@ mod tests {
 
     const TEST_BEACON_BLOCK_ID: u32 = 741888;
     const BEACON_ENDPOINT: &str = "https://lodestar-kiln.chainsafe.io";
-    const TIMEOUT: u64 = 30;
-    const TIMEOUT_STATE: u64 = 1000;
+    const TIMEOUT_SECONDS: u64 = 30;
+    const TIMEOUT_STATE_SECONDS: u64 = 1000;
 
     #[test]
     fn test_get_header_from_json() {
@@ -528,7 +528,7 @@ mod tests {
         let file_json_str = read_json_file_from_data_dir("beacon_block_kiln_slot_741888.json");
 
         let url = "https://lodestar-kiln.chainsafe.io/eth/v2/beacon/blocks/741888";
-        let beacon_rpc_client = BeaconRPCClient::new(url, TIMEOUT, TIMEOUT_STATE);
+        let beacon_rpc_client = BeaconRPCClient::new(url, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let rpc_json_str = beacon_rpc_client.get_json_from_raw_request(url);
 
         assert_eq!(rpc_json_str.unwrap(), file_json_str.trim());
@@ -536,17 +536,17 @@ mod tests {
 
     #[test]
     fn test_rpc_beacon_block_body_and_header_smoke() {
-        let _beacon_block_body = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT, TIMEOUT_STATE)
+        let _beacon_block_body = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS)
             .get_beacon_block_body_for_block_id(&TEST_BEACON_BLOCK_ID.to_string())
             .unwrap();
-        let _beacon_block_header = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT, TIMEOUT_STATE)
+        let _beacon_block_header = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS)
             .get_beacon_block_header_for_block_id(&TEST_BEACON_BLOCK_ID.to_string())
             .unwrap();
     }
 
     #[test]
     fn test_get_beacon_block_header() {
-        let beacon_block_header = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT, TIMEOUT_STATE)
+        let beacon_block_header = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS)
             .get_beacon_block_header_for_block_id(&TEST_BEACON_BLOCK_ID.to_string())
             .unwrap();
 
@@ -568,7 +568,7 @@ mod tests {
 
     #[test]
     fn test_get_beacon_block_body() {
-        let beacon_block_body = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT, TIMEOUT_STATE)
+        let beacon_block_body = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS)
             .get_beacon_block_body_for_block_id(&TEST_BEACON_BLOCK_ID.to_string())
             .unwrap();
         assert_eq!(beacon_block_body.attestations().len(), 29);
@@ -583,8 +583,8 @@ mod tests {
     fn test_is_sync() {
         assert!(!BeaconRPCClient::new(
             "https://lodestar-goerli.chainsafe.io",
-            TIMEOUT,
-            TIMEOUT_STATE
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS
         )
         .is_syncing()
         .unwrap());
@@ -627,7 +627,7 @@ mod tests {
     #[ignore]
     fn test_fetch_light_client_update() {
         const PERIOD: u64 = 100;
-        let beacon_rpc_client = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT, TIMEOUT_STATE);
+        let beacon_rpc_client = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let light_client_update = beacon_rpc_client.get_light_client_update(PERIOD).unwrap();
 
         // check attested_header

--- a/eth2near/eth2near-block-relay-rs/src/beacon_rpc_client.rs
+++ b/eth2near/eth2near-block-relay-rs/src/beacon_rpc_client.rs
@@ -255,6 +255,17 @@ impl BeaconRPCClient {
         Ok(serde_json::from_str(&state_json_str)?)
     }
 
+    pub fn is_syncing(&self) -> Result<bool, Box<dyn Error>> {
+        let url_request = format!(
+            "{}/eth/v1/node/syncing",
+            self.endpoint_url
+        );
+        let json_str = self.get_json_from_raw_request(&url_request)?;
+
+        let v: Value = serde_json::from_str(&json_str)?;
+        Ok(v["data"]["is_syncing"].as_bool().unwrap())
+    }
+
     fn get_json_from_raw_request(&self, url: &str) -> Result<String, Box<dyn Error>> {
         trace!(target: "relay", "Beacon chain request: {}", url);
         let json_str = self.client.get(url).send()?.text()?;
@@ -557,6 +568,11 @@ mod tests {
             "0x95a8bfef2aa4b30e63647f0e8eef7352ebac10a066acf8e24c3387982faffae2"
         );
         assert_eq!(beacon_block_body.eth1_data().deposit_count, 16392);
+    }
+
+    #[test]
+    fn test_is_sync() {
+        assert!(!BeaconRPCClient::new("https://lodestar-goerli.chainsafe.io").is_syncing().unwrap());
     }
 
     #[test]

--- a/eth2near/eth2near-block-relay-rs/src/beacon_rpc_client.rs
+++ b/eth2near/eth2near-block-relay-rs/src/beacon_rpc_client.rs
@@ -536,19 +536,22 @@ mod tests {
 
     #[test]
     fn test_rpc_beacon_block_body_and_header_smoke() {
-        let _beacon_block_body = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS)
-            .get_beacon_block_body_for_block_id(&TEST_BEACON_BLOCK_ID.to_string())
-            .unwrap();
-        let _beacon_block_header = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS)
-            .get_beacon_block_header_for_block_id(&TEST_BEACON_BLOCK_ID.to_string())
-            .unwrap();
+        let _beacon_block_body =
+            BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS)
+                .get_beacon_block_body_for_block_id(&TEST_BEACON_BLOCK_ID.to_string())
+                .unwrap();
+        let _beacon_block_header =
+            BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS)
+                .get_beacon_block_header_for_block_id(&TEST_BEACON_BLOCK_ID.to_string())
+                .unwrap();
     }
 
     #[test]
     fn test_get_beacon_block_header() {
-        let beacon_block_header = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS)
-            .get_beacon_block_header_for_block_id(&TEST_BEACON_BLOCK_ID.to_string())
-            .unwrap();
+        let beacon_block_header =
+            BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS)
+                .get_beacon_block_header_for_block_id(&TEST_BEACON_BLOCK_ID.to_string())
+                .unwrap();
 
         assert_eq!(beacon_block_header.slot, 741888);
         assert_eq!(beacon_block_header.proposer_index, 5407);
@@ -568,9 +571,10 @@ mod tests {
 
     #[test]
     fn test_get_beacon_block_body() {
-        let beacon_block_body = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS)
-            .get_beacon_block_body_for_block_id(&TEST_BEACON_BLOCK_ID.to_string())
-            .unwrap();
+        let beacon_block_body =
+            BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS)
+                .get_beacon_block_body_for_block_id(&TEST_BEACON_BLOCK_ID.to_string())
+                .unwrap();
         assert_eq!(beacon_block_body.attestations().len(), 29);
         assert_eq!(
             format!("{:?}", beacon_block_body.eth1_data().block_hash),
@@ -627,7 +631,8 @@ mod tests {
     #[ignore]
     fn test_fetch_light_client_update() {
         const PERIOD: u64 = 100;
-        let beacon_rpc_client = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        let beacon_rpc_client =
+            BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let light_client_update = beacon_rpc_client.get_light_client_update(PERIOD).unwrap();
 
         // check attested_header

--- a/eth2near/eth2near-block-relay-rs/src/beacon_rpc_client.rs
+++ b/eth2near/eth2near-block-relay-rs/src/beacon_rpc_client.rs
@@ -43,7 +43,7 @@ impl BeaconRPCClient {
         Self {
             endpoint_url: endpoint_url.to_string(),
             client: reqwest::blocking::Client::builder()
-                .timeout(Duration::from_secs(180))
+                .timeout(Duration::from_secs(1800))
                 .build()
                 .unwrap(),
         }

--- a/eth2near/eth2near-block-relay-rs/src/beacon_rpc_client.rs
+++ b/eth2near/eth2near-block-relay-rs/src/beacon_rpc_client.rs
@@ -1,5 +1,9 @@
 use crate::execution_block_proof::ExecutionBlockProof;
-use crate::relay_errors::{ExecutionPayloadError, FailOnGettingJson, MissSyncAggregationError, NoBlockForSlotError, SignatureSlotNotFoundError};
+use crate::relay_errors::{
+    ExecutionPayloadError, FailOnGettingJson, MissSyncAggregationError, NoBlockForSlotError,
+    SignatureSlotNotFoundError,
+};
+use contract_wrapper::utils::trim_quotes;
 use eth_types::eth2::BeaconBlockHeader;
 use eth_types::eth2::FinalizedHeaderUpdate;
 use eth_types::eth2::HeaderUpdate;
@@ -17,7 +21,6 @@ use std::string::String;
 use std::time::Duration;
 use types::MainnetEthSpec;
 use types::{BeaconBlockBody, BeaconState};
-use contract_wrapper::utils::trim_quotes;
 
 /// `BeaconRPCClient` allows getting beacon block body, beacon block header
 /// and light client updates
@@ -256,10 +259,7 @@ impl BeaconRPCClient {
     }
 
     pub fn is_syncing(&self) -> Result<bool, Box<dyn Error>> {
-        let url_request = format!(
-            "{}/eth/v1/node/syncing",
-            self.endpoint_url
-        );
+        let url_request = format!("{}/eth/v1/node/syncing", self.endpoint_url);
         let json_str = self.get_json_from_raw_request(&url_request)?;
 
         let v: Value = serde_json::from_str(&json_str)?;
@@ -270,9 +270,7 @@ impl BeaconRPCClient {
         trace!(target: "relay", "Beacon chain request: {}", url);
         let json_str = self.client.get(url).send()?.text()?;
         if let Err(_) = serde_json::from_str::<Value>(&json_str) {
-            return Err(Box::new(FailOnGettingJson {
-                response: json_str,
-            }));
+            return Err(Box::new(FailOnGettingJson { response: json_str }));
         }
 
         Ok(json_str)
@@ -572,7 +570,11 @@ mod tests {
 
     #[test]
     fn test_is_sync() {
-        assert!(!BeaconRPCClient::new("https://lodestar-goerli.chainsafe.io").is_syncing().unwrap());
+        assert!(
+            !BeaconRPCClient::new("https://lodestar-goerli.chainsafe.io")
+                .is_syncing()
+                .unwrap()
+        );
     }
 
     #[test]

--- a/eth2near/eth2near-block-relay-rs/src/beacon_rpc_client.rs
+++ b/eth2near/eth2near-block-relay-rs/src/beacon_rpc_client.rs
@@ -30,9 +30,9 @@ pub struct BeaconRPCClient {
 impl BeaconRPCClient {
     const URL_HEADER_PATH: &'static str = "eth/v1/beacon/headers";
     const URL_BODY_PATH: &'static str = "eth/v2/beacon/blocks";
-    const URL_GET_LIGHT_CLIENT_UPDATE_API: &'static str = "eth/v1/light_client/updates";
+    const URL_GET_LIGHT_CLIENT_UPDATE_API: &'static str = "eth/v1/beacon/light_client/updates";
     const URL_FINALITY_LIGHT_CLIENT_UPDATE_PATH: &'static str =
-        "eth/v1/light_client/finality_update/";
+        "eth/v1/beacon/light_client/finality_update/";
     const URL_STATE_PATH: &'static str = "eth/v2/debug/beacon/states";
 
     const SLOTS_PER_EPOCH: u64 = 32;

--- a/eth2near/eth2near-block-relay-rs/src/config.rs
+++ b/eth2near/eth2near-block-relay-rs/src/config.rs
@@ -43,7 +43,7 @@ pub struct Config {
     pub near_network_id: String,
 
     // Port for Prometheus
-    pub prometheus_metrics_port: u16,
+    pub prometheus_metrics_port: Option<u16>,
 
     // Account id for DAO on NEAR
     pub dao_contract_account_id: Option<String>,

--- a/eth2near/eth2near-block-relay-rs/src/config.rs
+++ b/eth2near/eth2near-block-relay-rs/src/config.rs
@@ -27,7 +27,7 @@ pub struct Config {
     // Account id for eth client contract on NEAR
     pub contract_account_id: String,
 
-    // The Ethereum network name (main, kiln)
+    // The Ethereum network name (main, kiln, ropsten, goerli)
     pub network: String,
 
     // Contract type (near, dao, file)
@@ -73,7 +73,6 @@ impl Config {
         Self::check_urls(&config);
         Self::check_account_id(&config);
         Self::check_network_types(&config);
-        Self::check_update_frequency(&config);
 
         config
     }
@@ -128,6 +127,27 @@ impl Config {
         }
     }
 
-    fn check_network_types(&self) {}
-    fn check_update_frequency(&self) {}
+    fn check_network_types(&self) {
+        //check network
+        if !(self.network == "main" ||
+            self.network == "kiln" ||
+            self.network == "ropsten" ||
+            self.network == "goerli") {
+            panic!("Unknown network {}", self.network);
+        }
+
+        //check contract_type
+        if !(self.contract_type == "near" ||
+            self.contract_type == "dao" ||
+            self.contract_type == "file") {
+            panic!("Unknown contract type {}", self.contract_type);
+        }
+
+        //check near_network_id
+        if !(self.near_network_id == "mainnet" ||
+             self.near_network_id == "testnet") {
+            panic!("Unknown near network id {}", self.near_network_id);
+        }
+    }
 }
+

--- a/eth2near/eth2near-block-relay-rs/src/config.rs
+++ b/eth2near/eth2near-block-relay-rs/src/config.rs
@@ -57,10 +57,10 @@ pub struct Config {
     pub path_to_finality_state: Option<String>,
 
     //Timeout for ETH RPC requests in secs
-    pub eth_requests_timeout: u64,
+    pub eth_requests_timeout_seconds: u64,
 
     //Timeout for ETH RPC get status requests in secs
-    pub state_requests_timeout: u64,
+    pub state_requests_timeout_seconds: u64,
 }
 
 impl Config {

--- a/eth2near/eth2near-block-relay-rs/src/config.rs
+++ b/eth2near/eth2near-block-relay-rs/src/config.rs
@@ -59,16 +59,16 @@ pub struct Config {
     // for case of short relay run
     pub path_to_finality_state: Option<String>,
 
-    //Timeout for ETH RPC requests in secs
+    // Timeout for ETH RPC requests in seconds
     pub eth_requests_timeout_seconds: u64,
 
-    //Timeout for ETH RPC get status requests in secs
+    // Timeout for ETH RPC get status requests in seconds
     pub state_requests_timeout_seconds: u64,
 
-    //Sleep time in seconds when ETH client is synchronized with ETH network
+    // Sleep time in seconds when ETH client is synchronized with ETH network
     pub sleep_time_on_sync_secs: u64,
 
-    //Sleep time in seconds after blocks/light_client_update submission to client
+    // Sleep time in seconds after blocks/light_client_update submission to client
     pub sleep_time_after_submission_secs: u64,
 }
 
@@ -102,20 +102,18 @@ impl Config {
 
         // check `signer_account_id`
         let _signer_account_id: near_sdk::AccountId = self.signer_account_id.parse().unwrap();
-        if near_rpc_client
+        if !near_rpc_client
             .check_account_exists(&self.signer_account_id)
             .unwrap()
-            == false
         {
             panic!("Signer account id doesn't exist on NEAR network");
         }
 
         // check `contract_account_id`
         let _contract_account_id: near_sdk::AccountId = self.contract_account_id.parse().unwrap();
-        if near_rpc_client
+        if !near_rpc_client
             .check_account_exists(&self.contract_account_id)
             .unwrap()
-            == false
         {
             panic!("Contract account id doesn't exist on NEAR network");
         }
@@ -124,10 +122,9 @@ impl Config {
         if let Some(dao_contract_account_id) = self.dao_contract_account_id.clone() {
             let _dao_contract_account_id: near_sdk::AccountId =
                 dao_contract_account_id.parse().unwrap();
-            if near_rpc_client
+            if !near_rpc_client
                 .check_account_exists(&dao_contract_account_id)
                 .unwrap()
-                == false
             {
                 panic!("DAO account id doesn't exist on NEAR network");
             }

--- a/eth2near/eth2near-block-relay-rs/src/config.rs
+++ b/eth2near/eth2near-block-relay-rs/src/config.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 use std::io::Read;
 use std::path::PathBuf;
-use std::time::Duration;
+use reqwest::Url;
 use crate::near_rpc_client::NearRPCClient;
 
 #[derive(Deserialize, Debug, Clone)]
@@ -78,29 +78,14 @@ impl Config {
     }
 
     fn check_urls(&self) {
-        let timeout = Duration::new(5, 0);
-        let client = reqwest::blocking::Client::builder()
-            .timeout(timeout)
-            .build()
-            .unwrap();
-
         //check beacon_endpoint
-        let response = client.head(&self.beacon_endpoint).send().unwrap();
-        if !response.status().is_success() {
-            panic!("Beacon_endpoint not available");
-        }
+        Url::parse(&self.beacon_endpoint).unwrap();
 
         //check eth1_endpoint
-        let response = client.head(&self.eth1_endpoint).send().unwrap();
-        if !response.status().is_success() {
-            panic!("Eth1_endpoint not available");
-        }
+        Url::parse(&self.eth1_endpoint).unwrap();
 
         //check near_endpoint
-        let response = client.head(&self.near_endpoint).send().unwrap();
-        if !response.status().is_success() {
-            panic!("Near_endpoint not available");
-        }
+        Url::parse(&self.near_endpoint).unwrap();
     }
 
     fn check_account_id(&self) {

--- a/eth2near/eth2near-block-relay-rs/src/config.rs
+++ b/eth2near/eth2near-block-relay-rs/src/config.rs
@@ -1,8 +1,8 @@
+use crate::near_rpc_client::NearRPCClient;
+use reqwest::Url;
 use serde::Deserialize;
 use std::io::Read;
 use std::path::PathBuf;
-use reqwest::Url;
-use crate::near_rpc_client::NearRPCClient;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Config {
@@ -61,6 +61,12 @@ pub struct Config {
 
     //Timeout for ETH RPC get status requests in secs
     pub state_requests_timeout_seconds: u64,
+
+    //Sleep time in seconds when ETH client is synchronized with ETH network
+    pub sleep_time_on_sync_secs: u64,
+
+    //Sleep time in seconds after blocks/light_client_update submission to client
+    pub sleep_time_after_submission_secs: u64,
 }
 
 impl Config {
@@ -93,20 +99,33 @@ impl Config {
 
         // check `signer_account_id`
         let _signer_account_id: near_sdk::AccountId = self.signer_account_id.parse().unwrap();
-        if near_rpc_client.check_account_exists(&self.signer_account_id).unwrap() == false {
+        if near_rpc_client
+            .check_account_exists(&self.signer_account_id)
+            .unwrap()
+            == false
+        {
             panic!("Signer account id doesn't exist on NEAR network");
         }
 
         // check `contract_account_id`
         let _contract_account_id: near_sdk::AccountId = self.contract_account_id.parse().unwrap();
-        if near_rpc_client.check_account_exists(&self.contract_account_id).unwrap() == false {
+        if near_rpc_client
+            .check_account_exists(&self.contract_account_id)
+            .unwrap()
+            == false
+        {
             panic!("Contract account id doesn't exist on NEAR network");
         }
 
         // check `dao_contract_account_id`
         if let Some(dao_contract_account_id) = self.dao_contract_account_id.clone() {
-            let _dao_contract_account_id: near_sdk::AccountId = dao_contract_account_id.parse().unwrap();
-            if near_rpc_client.check_account_exists(&dao_contract_account_id).unwrap() == false {
+            let _dao_contract_account_id: near_sdk::AccountId =
+                dao_contract_account_id.parse().unwrap();
+            if near_rpc_client
+                .check_account_exists(&dao_contract_account_id)
+                .unwrap()
+                == false
+            {
                 panic!("DAO account id doesn't exist on NEAR network");
             }
         }
@@ -114,25 +133,25 @@ impl Config {
 
     fn check_network_types(&self) {
         // check `network`
-        if !(self.network == "main" ||
-            self.network == "kiln" ||
-            self.network == "ropsten" ||
-            self.network == "goerli") {
+        if !(self.network == "main"
+            || self.network == "kiln"
+            || self.network == "ropsten"
+            || self.network == "goerli")
+        {
             panic!("Unknown network {}", self.network);
         }
 
         // check `contract_type`
-        if !(self.contract_type == "near" ||
-            self.contract_type == "dao" ||
-            self.contract_type == "file") {
+        if !(self.contract_type == "near"
+            || self.contract_type == "dao"
+            || self.contract_type == "file")
+        {
             panic!("Unknown contract type {}", self.contract_type);
         }
 
         // check `near_network_id`
-        if !(self.near_network_id == "mainnet" ||
-             self.near_network_id == "testnet") {
+        if !(self.near_network_id == "mainnet" || self.near_network_id == "testnet") {
             panic!("Unknown near network id {}", self.near_network_id);
         }
     }
 }
-

--- a/eth2near/eth2near-block-relay-rs/src/config.rs
+++ b/eth2near/eth2near-block-relay-rs/src/config.rs
@@ -78,32 +78,32 @@ impl Config {
     }
 
     fn check_urls(&self) {
-        //check beacon_endpoint
+        // check `beacon_endpoint`
         Url::parse(&self.beacon_endpoint).unwrap();
 
-        //check eth1_endpoint
+        // check `eth1_endpoint`
         Url::parse(&self.eth1_endpoint).unwrap();
 
-        //check near_endpoint
+        // check `near_endpoint`
         Url::parse(&self.near_endpoint).unwrap();
     }
 
     fn check_account_id(&self) {
         let near_rpc_client = NearRPCClient::new(&self.near_endpoint);
 
-        //check signer_account_id
+        // check `signer_account_id`
         let _signer_account_id: near_sdk::AccountId = self.signer_account_id.parse().unwrap();
         if near_rpc_client.check_account_exists(&self.signer_account_id).unwrap() == false {
             panic!("Signer account id doesn't exist on NEAR network");
         }
 
-        //check contract_account_id
+        // check `contract_account_id`
         let _contract_account_id: near_sdk::AccountId = self.contract_account_id.parse().unwrap();
         if near_rpc_client.check_account_exists(&self.contract_account_id).unwrap() == false {
             panic!("Contract account id doesn't exist on NEAR network");
         }
 
-        //check dao_contract_account_id
+        // check `dao_contract_account_id`
         if let Some(dao_contract_account_id) = self.dao_contract_account_id.clone() {
             let _dao_contract_account_id: near_sdk::AccountId = dao_contract_account_id.parse().unwrap();
             if near_rpc_client.check_account_exists(&dao_contract_account_id).unwrap() == false {
@@ -113,7 +113,7 @@ impl Config {
     }
 
     fn check_network_types(&self) {
-        //check network
+        // check `network`
         if !(self.network == "main" ||
             self.network == "kiln" ||
             self.network == "ropsten" ||
@@ -121,14 +121,14 @@ impl Config {
             panic!("Unknown network {}", self.network);
         }
 
-        //check contract_type
+        // check `contract_type`
         if !(self.contract_type == "near" ||
             self.contract_type == "dao" ||
             self.contract_type == "file") {
             panic!("Unknown contract type {}", self.contract_type);
         }
 
-        //check near_network_id
+        // check `near_network_id`
         if !(self.near_network_id == "mainnet" ||
              self.near_network_id == "testnet") {
             panic!("Unknown near network id {}", self.near_network_id);

--- a/eth2near/eth2near-block-relay-rs/src/config.rs
+++ b/eth2near/eth2near-block-relay-rs/src/config.rs
@@ -53,6 +53,12 @@ pub struct Config {
     // Path to the json file with beacon state in the next finality slot
     // for case of short relay run
     pub path_to_finality_state: Option<String>,
+
+    //Timeout for ETH RPC requests in secs
+    pub eth_requests_timeout: u64,
+
+    //Timeout for ETH RPC get status requests in secs
+    pub state_requests_timeout: u64,
 }
 
 impl Config {

--- a/eth2near/eth2near-block-relay-rs/src/eth1_rpc_client.rs
+++ b/eth2near/eth2near-block-relay-rs/src/eth1_rpc_client.rs
@@ -72,9 +72,9 @@ impl Eth1RPCClient {
         let is_sync = val["result"].as_bool();
         if let Some(is_sync_val) = is_sync {
             return Ok(is_sync_val);
-        } else {
-            return Ok(true);
         }
+        
+        Ok(true)
     }
 }
 

--- a/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
+++ b/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
@@ -12,6 +12,7 @@ use std::error::Error;
 use std::thread::sleep;
 use std::time::Duration;
 use std::vec::Vec;
+use crate::near_rpc_client::NearRPCClient;
 
 const ONE_EPOCH_IN_SLOTS: u64 = 32;
 
@@ -42,6 +43,7 @@ macro_rules! return_on_fail {
 pub struct Eth2NearRelay {
     beacon_rpc_client: BeaconRPCClient,
     eth1_rpc_client: Eth1RPCClient,
+    near_rpc_client: NearRPCClient,
     eth_client_contract: Box<dyn EthClientContractTrait>,
     max_submitted_headers: u64,
     network: String,
@@ -76,6 +78,7 @@ impl Eth2NearRelay {
             beacon_rpc_client,
             eth1_rpc_client: Eth1RPCClient::new(&config.eth1_endpoint),
             eth_client_contract: eth_contract,
+            near_rpc_client: NearRPCClient::new(&config.near_endpoint),
             max_submitted_headers: config.total_submit_headers as u64,
             network: config.network.to_string(),
             light_client_updates_submission_frequency_in_epochs: config
@@ -154,7 +157,9 @@ impl Eth2NearRelay {
     }
 
     fn wait_for_synchronization(&self) -> Result<(), Box<dyn Error>> {
-        while self.beacon_rpc_client.is_syncing()? || self.eth1_rpc_client.is_syncing()? {
+        while self.beacon_rpc_client.is_syncing()? ||
+              self.eth1_rpc_client.is_syncing()? ||
+              self.near_rpc_client.is_syncing()? {
             info!(target: "relay", "Waiting for sync...");
             sleep(Duration::from_secs(30));
         }

--- a/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
+++ b/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
@@ -538,6 +538,18 @@ mod tests {
     }
 
     #[test]
+    fn test_submit_zero_headers() {
+        let mut relay = get_relay(true, true);
+        let mut end_slot = get_finalized_slot(&relay);
+        end_slot += 1;
+
+        let blocks: Vec<BlockHeader> = vec![];
+        if let Ok(_) = relay.eth_client_contract.send_headers(&blocks, end_slot) {
+            panic!("No error on submit 0 headers");
+        }
+    }
+
+    #[test]
     fn test_send_specific_light_client_update() {
         let mut relay = get_relay(true, true);
         let finalized_slot = get_finalized_slot(&relay);

--- a/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
+++ b/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
@@ -107,8 +107,9 @@ impl Eth2NearRelay {
                 .unwrap();
         }
 
-        let port = config.prometheus_metrics_port.clone();
-        spawn(move || {prometheus_metrics::run_prometheus_service(port)});
+        if let Some(port) = config.prometheus_metrics_port {
+            spawn(move || prometheus_metrics::run_prometheus_service(port));
+        }
 
         eth2near_relay
     }

--- a/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
+++ b/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
@@ -102,6 +102,7 @@ impl Eth2NearRelay {
             self.set_terminate(iter_id, max_iterations);
 
             info!(target: "relay", "== New relay loop ==");
+            sleep(Duration::from_secs(12));
 
             let last_eth2_slot_on_eth_chain: u64 = if self.submit_only_finalized_blocks {
                 skip_fail!(
@@ -138,10 +139,11 @@ impl Eth2NearRelay {
                     "Network problems during fetching execution blocks"
                 );
                 self.submit_execution_blocks(headers, current_slot, &mut last_eth2_slot_on_near);
+                sleep(Duration::from_secs(5));
                 self.send_light_client_updates(last_eth2_slot_on_near);
             } else {
-                info!(target: "relay", "Sync with ETH network. Sleep 20 secs");
-                sleep(Duration::from_secs(20));
+                info!(target: "relay", "Sync with ETH network. Sleep 30 secs");
+                sleep(Duration::from_secs(30));
             }
         }
     }

--- a/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
+++ b/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
@@ -22,6 +22,8 @@ macro_rules! skip_fail {
             Ok(val) => val,
             Err(e) => {
                 warn!(target: "relay", "{}. Error: {}", $msg, e);
+                trace!(target: "relay", "Sleep 12 secs before next loop");
+                sleep(Duration::from_secs(12));
                 continue;
             }
         }
@@ -110,7 +112,6 @@ impl Eth2NearRelay {
             skip_fail!(self.wait_for_synchronization(), "Fail to get sync status");
 
             info!(target: "relay", "== New relay loop ==");
-            sleep(Duration::from_secs(12));
 
             let last_eth2_slot_on_eth_chain: u64 = if self.submit_only_finalized_blocks {
                 skip_fail!(
@@ -495,6 +496,7 @@ impl Eth2NearRelay {
 
             info!(target: "relay", "Successful light client update submission! Transaction URL: https://explorer.{}.near.org/transactions/{}",
                                   self.near_network_name, execution_outcome.transaction.hash);
+            sleep(Duration::from_secs(5));
         } else {
             debug!(target: "relay", "Finalized block for light client update is not found on NEAR. Skipping send light client update");
         }

--- a/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
+++ b/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
@@ -68,8 +68,8 @@ impl Eth2NearRelay {
 
         let beacon_rpc_client = BeaconRPCClient::new(
             &config.beacon_endpoint,
-            config.eth_requests_timeout,
-            config.state_requests_timeout,
+            config.eth_requests_timeout_seconds,
+            config.state_requests_timeout_seconds,
         );
         let next_light_client_update =
             Self::get_light_client_update_from_file(config, &beacon_rpc_client).unwrap();
@@ -519,8 +519,8 @@ mod tests {
     const FINALIZED_SLOT_7: u64 = 1099808;
     const FINALIZED_SLOT_8: u64 = 1099872;
     const FINALIZED_SLOT_BEFORE_NEW_PERIOD: u64 = 1105919;
-    const TIMEOUT: u64 = 30;
-    const TIMEOUT_STATE: u64 = 1000;
+    const TIMEOUT_SECONDS: u64 = 30;
+    const TIMEOUT_STATE_SECONDS: u64 = 1000;
 
     fn send_execution_blocks_between(relay: &mut Eth2NearRelay, start_slot: u64, end_slot: u64) {
         let mut slot = start_slot;
@@ -677,7 +677,7 @@ mod tests {
         }
 
         relay.beacon_rpc_client =
-            BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT, TIMEOUT_STATE);
+            BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         if let Err(err) = relay.get_execution_block_by_slot(SLOT_WITHOUT_BLOCK) {
             if err.downcast_ref::<NoBlockForSlotError>().is_some() {
                 panic!("Wrong error type for unworking network");
@@ -824,7 +824,7 @@ mod tests {
         let finalized_slot = get_finalized_slot(&relay);
 
         relay.beacon_rpc_client =
-            BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT, TIMEOUT_STATE);
+            BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         relay
             .get_execution_blocks_between(finalized_slot + 1, RIGHT_BOUND_IN_SLOT_SEARCH)
             .unwrap();

--- a/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
+++ b/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
@@ -9,6 +9,8 @@ use eth_types::eth2::LightClientUpdate;
 use eth_types::BlockHeader;
 use log::{debug, info, trace, warn};
 use std::error::Error;
+use std::thread::sleep;
+use std::time::Duration;
 use std::vec::Vec;
 
 const ONE_EPOCH_IN_SLOTS: u64 = 32;
@@ -137,6 +139,9 @@ impl Eth2NearRelay {
                 );
                 self.submit_execution_blocks(headers, current_slot, &mut last_eth2_slot_on_near);
                 self.send_light_client_updates(last_eth2_slot_on_near);
+            } else {
+                info!(target: "relay", "Sync with ETH network. Sleep 20 secs");
+                sleep(Duration::from_secs(20));
             }
         }
     }

--- a/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
+++ b/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
@@ -323,8 +323,8 @@ impl Eth2NearRelay {
             return;
         }
 
-        if last_finalized_slot_on_eth - last_finalized_slot_on_near
-            >= self.max_blocks_for_finalization
+        if last_finalized_slot_on_eth
+            >= last_finalized_slot_on_near + self.max_blocks_for_finalization
         {
             info!(target: "relay", "Too big gap between slot of finalized block on Near and Eth. Sending hand made light client update");
             self.send_hand_made_light_client_update(last_finalized_slot_on_near);

--- a/eth2near/eth2near-block-relay-rs/src/execution_block_proof.rs
+++ b/eth2near/eth2near-block-relay-rs/src/execution_block_proof.rs
@@ -180,8 +180,11 @@ mod tests {
 
     #[test]
     fn test_beacon_block_body_root_matches_body_root_in_header() {
-        let beacon_rpc_client =
-            crate::beacon_rpc_client::BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        let beacon_rpc_client = crate::beacon_rpc_client::BeaconRPCClient::new(
+            BEACON_ENDPOINT,
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS,
+        );
         let beacon_block_body = beacon_rpc_client
             .get_beacon_block_body_for_block_id(&TEST_BEACON_BLOCK_ID.to_string())
             .unwrap();

--- a/eth2near/eth2near-block-relay-rs/src/execution_block_proof.rs
+++ b/eth2near/eth2near-block-relay-rs/src/execution_block_proof.rs
@@ -129,8 +129,8 @@ mod tests {
 
     const TEST_BEACON_BLOCK_ID: u32 = 741888;
     const BEACON_ENDPOINT: &str = "https://lodestar-kiln.chainsafe.io";
-    const TIMEOUT: u64 = 30;
-    const TIMEOUT_STATE: u64 = 1000;
+    const TIMEOUT_SECONDS: u64 = 30;
+    const TIMEOUT_STATE_SECONDS: u64 = 1000;
 
     #[test]
     fn test_beacon_block_body_root_verification() {
@@ -181,7 +181,7 @@ mod tests {
     #[test]
     fn test_beacon_block_body_root_matches_body_root_in_header() {
         let beacon_rpc_client =
-            crate::beacon_rpc_client::BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT, TIMEOUT_STATE);
+            crate::beacon_rpc_client::BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let beacon_block_body = beacon_rpc_client
             .get_beacon_block_body_for_block_id(&TEST_BEACON_BLOCK_ID.to_string())
             .unwrap();

--- a/eth2near/eth2near-block-relay-rs/src/execution_block_proof.rs
+++ b/eth2near/eth2near-block-relay-rs/src/execution_block_proof.rs
@@ -129,6 +129,8 @@ mod tests {
 
     const TEST_BEACON_BLOCK_ID: u32 = 741888;
     const BEACON_ENDPOINT: &str = "https://lodestar-kiln.chainsafe.io";
+    const TIMEOUT: u64 = 30;
+    const TIMEOUT_STATE: u64 = 1000;
 
     #[test]
     fn test_beacon_block_body_root_verification() {
@@ -178,7 +180,8 @@ mod tests {
 
     #[test]
     fn test_beacon_block_body_root_matches_body_root_in_header() {
-        let beacon_rpc_client = crate::beacon_rpc_client::BeaconRPCClient::new(BEACON_ENDPOINT);
+        let beacon_rpc_client =
+            crate::beacon_rpc_client::BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT, TIMEOUT_STATE);
         let beacon_block_body = beacon_rpc_client
             .get_beacon_block_body_for_block_id(&TEST_BEACON_BLOCK_ID.to_string())
             .unwrap();

--- a/eth2near/eth2near-block-relay-rs/src/hand_made_finality_light_client_update.rs
+++ b/eth2near/eth2near-block-relay-rs/src/hand_made_finality_light_client_update.rs
@@ -333,6 +333,8 @@ mod tests {
     const ATTESTED_SLOT: u64 = 812637;
     const BEACON_ENDPOINT: &str = "https://lodestar-kiln.chainsafe.io";
     const LIGHT_CLIENT_UPDATE_PERIOD: u64 = 99;
+    const TIMEOUT: u64 = 30;
+    const TIMEOUT_STATE: u64 = 1000;
 
     fn cmp_light_client_updates(
         hand_made_light_client_update: &LightClientUpdate,
@@ -359,7 +361,7 @@ mod tests {
     #[ignore]
     #[test]
     fn test_hand_made_finality_light_client_update() {
-        let beacon_rpc_client = BeaconRPCClient::new(BEACON_ENDPOINT);
+        let beacon_rpc_client = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT, TIMEOUT_STATE);
         let hand_made_light_client_update =
             HandMadeFinalityLightClientUpdate::get_finality_light_client_update(
                 &beacon_rpc_client,
@@ -381,7 +383,7 @@ mod tests {
 
     #[test]
     fn test_hand_made_finality_light_client_update_from_file() {
-        let beacon_rpc_client = BeaconRPCClient::new(BEACON_ENDPOINT);
+        let beacon_rpc_client = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT, TIMEOUT_STATE);
         let hand_made_light_client_update =
             HandMadeFinalityLightClientUpdate::get_finality_light_client_update_from_file(
                 &beacon_rpc_client,
@@ -397,7 +399,7 @@ mod tests {
 
     #[test]
     fn test_hand_made_finality_light_client_update_from_file_with_next_sync_committee() {
-        let beacon_rpc_client = BeaconRPCClient::new(BEACON_ENDPOINT);
+        let beacon_rpc_client = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT, TIMEOUT_STATE);
         let hand_made_light_client_update =
             HandMadeFinalityLightClientUpdate::get_light_client_update_from_file_with_next_sync_committee(
                 &beacon_rpc_client,

--- a/eth2near/eth2near-block-relay-rs/src/hand_made_finality_light_client_update.rs
+++ b/eth2near/eth2near-block-relay-rs/src/hand_made_finality_light_client_update.rs
@@ -1,15 +1,17 @@
 use crate::beacon_block_body_merkle_tree::BeaconStateMerkleTree;
 use crate::beacon_rpc_client::BeaconRPCClient;
 use crate::execution_block_proof::ExecutionBlockProof;
-use crate::relay_errors::{ErrorOnUnwrapSignatureBit, MissNextSyncCommittee, MissSyncAggregationError, NoBlockForSlotError};
+use crate::relay_errors::{
+    ErrorOnUnwrapSignatureBit, MissNextSyncCommittee, MissSyncAggregationError, NoBlockForSlotError,
+};
 use eth_types::eth2::{
     FinalizedHeaderUpdate, HeaderUpdate, LightClientUpdate, SignatureBytes, SyncCommittee,
     SyncCommitteeBits, SyncCommitteeUpdate,
 };
 use eth_types::H256;
+use log::trace;
 use serde_json::Value;
 use std::error::Error;
-use log::trace;
 use tree_hash::TreeHash;
 use types::{BeaconBlockBody, BeaconBlockHeader, BeaconState, MainnetEthSpec};
 
@@ -21,7 +23,11 @@ impl HandMadeFinalityLightClientUpdate {
         attested_slot: u64,
         include_next_sync_committee: bool,
     ) -> Result<LightClientUpdate, Box<dyn Error>> {
-        let (attested_slot, signature_slot) = Self::get_attested_slot_with_enough_sync_committee_bits_sum(&beacon_rpc_client, attested_slot)?;
+        let (attested_slot, signature_slot) =
+            Self::get_attested_slot_with_enough_sync_committee_bits_sum(
+                &beacon_rpc_client,
+                attested_slot,
+            )?;
         trace!(target: "relay", "New attested slot = {} and signature slot = {}", attested_slot, signature_slot);
         let beacon_state = beacon_rpc_client.get_beacon_state(&format!("{}", attested_slot))?;
 
@@ -89,21 +95,27 @@ impl HandMadeFinalityLightClientUpdate {
 }
 
 impl HandMadeFinalityLightClientUpdate {
-    fn get_attested_slot_with_enough_sync_committee_bits_sum(beacon_rpc_client: &BeaconRPCClient,
-                                                              attested_slot: u64) -> Result<(u64, u64), Box<dyn Error>> {
+    fn get_attested_slot_with_enough_sync_committee_bits_sum(
+        beacon_rpc_client: &BeaconRPCClient,
+        attested_slot: u64,
+    ) -> Result<(u64, u64), Box<dyn Error>> {
         let mut current_attested_slot = attested_slot;
         loop {
             let signature_slot = beacon_rpc_client
                 .get_non_empty_beacon_block_header(current_attested_slot + 1)?
                 .slot
                 .into();
-            let signature_beacon_body =
-                beacon_rpc_client.get_beacon_block_body_for_block_id(&format!("{}", signature_slot))?;
+            let signature_beacon_body = beacon_rpc_client
+                .get_beacon_block_body_for_block_id(&format!("{}", signature_slot))?;
             let sync_committe_signature = signature_beacon_body
                 .sync_aggregate()
                 .map_err(|_| MissSyncAggregationError)?;
-            let sync_committee_bits: [u8; 64] = Self::get_sync_committee_bits(sync_committe_signature)?;
-            let sync_committee_bits_sum: u32 = sync_committee_bits.into_iter().map(|x| x.count_ones()).sum();
+            let sync_committee_bits: [u8; 64] =
+                Self::get_sync_committee_bits(sync_committe_signature)?;
+            let sync_committee_bits_sum: u32 = sync_committee_bits
+                .into_iter()
+                .map(|x| x.count_ones())
+                .sum();
             if sync_committee_bits_sum * 3 < (64 * 8 * 2) {
                 current_attested_slot = signature_slot;
                 continue;
@@ -115,10 +127,12 @@ impl HandMadeFinalityLightClientUpdate {
                 continue;
             }
 
-            if let Err(err) = beacon_rpc_client.get_beacon_block_header_for_block_id(&format!("{}", current_attested_slot)) {
+            if let Err(err) = beacon_rpc_client
+                .get_beacon_block_header_for_block_id(&format!("{}", current_attested_slot))
+            {
                 if let Some(_) = err.downcast_ref::<NoBlockForSlotError>() {
                     current_attested_slot = signature_slot;
-                    continue
+                    continue;
                 }
                 return Err(err);
             }

--- a/eth2near/eth2near-block-relay-rs/src/hand_made_finality_light_client_update.rs
+++ b/eth2near/eth2near-block-relay-rs/src/hand_made_finality_light_client_update.rs
@@ -361,7 +361,8 @@ mod tests {
     #[ignore]
     #[test]
     fn test_hand_made_finality_light_client_update() {
-        let beacon_rpc_client = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        let beacon_rpc_client =
+            BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let hand_made_light_client_update =
             HandMadeFinalityLightClientUpdate::get_finality_light_client_update(
                 &beacon_rpc_client,
@@ -383,7 +384,8 @@ mod tests {
 
     #[test]
     fn test_hand_made_finality_light_client_update_from_file() {
-        let beacon_rpc_client = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        let beacon_rpc_client =
+            BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let hand_made_light_client_update =
             HandMadeFinalityLightClientUpdate::get_finality_light_client_update_from_file(
                 &beacon_rpc_client,
@@ -399,7 +401,8 @@ mod tests {
 
     #[test]
     fn test_hand_made_finality_light_client_update_from_file_with_next_sync_committee() {
-        let beacon_rpc_client = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        let beacon_rpc_client =
+            BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let hand_made_light_client_update =
             HandMadeFinalityLightClientUpdate::get_light_client_update_from_file_with_next_sync_committee(
                 &beacon_rpc_client,

--- a/eth2near/eth2near-block-relay-rs/src/hand_made_finality_light_client_update.rs
+++ b/eth2near/eth2near-block-relay-rs/src/hand_made_finality_light_client_update.rs
@@ -25,7 +25,7 @@ impl HandMadeFinalityLightClientUpdate {
     ) -> Result<LightClientUpdate, Box<dyn Error>> {
         let (attested_slot, signature_slot) =
             Self::get_attested_slot_with_enough_sync_committee_bits_sum(
-                &beacon_rpc_client,
+                beacon_rpc_client,
                 attested_slot,
             )?;
         trace!(target: "relay", "New attested slot = {} and signature slot = {}", attested_slot, signature_slot);
@@ -121,7 +121,7 @@ impl HandMadeFinalityLightClientUpdate {
                 continue;
             }
 
-            if signature_beacon_body.attestations().len() == 0 {
+            if signature_beacon_body.attestations().is_empty() {
                 current_attested_slot = signature_slot;
                 continue;
             }
@@ -135,7 +135,7 @@ impl HandMadeFinalityLightClientUpdate {
             if let Err(err) = beacon_rpc_client
                 .get_beacon_block_header_for_block_id(&format!("{}", current_attested_slot))
             {
-                if let Some(_) = err.downcast_ref::<NoBlockForSlotError>() {
+                if err.downcast_ref::<NoBlockForSlotError>().is_some() {
                     current_attested_slot = signature_slot;
                     continue;
                 }

--- a/eth2near/eth2near-block-relay-rs/src/hand_made_finality_light_client_update.rs
+++ b/eth2near/eth2near-block-relay-rs/src/hand_made_finality_light_client_update.rs
@@ -367,7 +367,9 @@ mod tests {
                 true,
             )
             .unwrap();
-        let light_client_update = beacon_rpc_client.get_light_client_update(LIGHT_CLIENT_UPDATE_PERIOD).unwrap();
+        let light_client_update = beacon_rpc_client
+            .get_light_client_update(LIGHT_CLIENT_UPDATE_PERIOD)
+            .unwrap();
 
         cmp_light_client_updates(&hand_made_light_client_update, &light_client_update);
 
@@ -386,7 +388,9 @@ mod tests {
                 "data/beacon_state_kiln_slot_812637_period_99.json",
             )
             .unwrap();
-        let light_client_update = beacon_rpc_client.get_light_client_update(LIGHT_CLIENT_UPDATE_PERIOD).unwrap();
+        let light_client_update = beacon_rpc_client
+            .get_light_client_update(LIGHT_CLIENT_UPDATE_PERIOD)
+            .unwrap();
 
         cmp_light_client_updates(&hand_made_light_client_update, &light_client_update);
     }
@@ -401,7 +405,9 @@ mod tests {
                 "data/beacon_state_kiln_slot_812544.json",
             ).unwrap();
 
-        let light_client_update = beacon_rpc_client.get_light_client_update(LIGHT_CLIENT_UPDATE_PERIOD).unwrap();
+        let light_client_update = beacon_rpc_client
+            .get_light_client_update(LIGHT_CLIENT_UPDATE_PERIOD)
+            .unwrap();
 
         cmp_light_client_updates(&hand_made_light_client_update, &light_client_update);
 

--- a/eth2near/eth2near-block-relay-rs/src/hand_made_finality_light_client_update.rs
+++ b/eth2near/eth2near-block-relay-rs/src/hand_made_finality_light_client_update.rs
@@ -1,9 +1,7 @@
 use crate::beacon_block_body_merkle_tree::BeaconStateMerkleTree;
 use crate::beacon_rpc_client::BeaconRPCClient;
 use crate::execution_block_proof::ExecutionBlockProof;
-use crate::relay_errors::{
-    ErrorOnUnwrapSignatureBit, MissNextSyncCommittee, MissSyncAggregationError, NoBlockForSlotError,
-};
+use crate::relay_errors::{ErrorOnUnwrapSignatureBit, MissNextSyncCommittee, MissSyncAggregationError, NoBlockForSlotError};
 use eth_types::eth2::{
     FinalizedHeaderUpdate, HeaderUpdate, LightClientUpdate, SignatureBytes, SyncCommittee,
     SyncCommitteeBits, SyncCommitteeUpdate,
@@ -117,6 +115,11 @@ impl HandMadeFinalityLightClientUpdate {
                 .map(|x| x.count_ones())
                 .sum();
             if sync_committee_bits_sum * 3 < (64 * 8 * 2) {
+                current_attested_slot = signature_slot;
+                continue;
+            }
+
+            if signature_beacon_body.attestations().len() == 0 {
                 current_attested_slot = signature_slot;
                 continue;
             }

--- a/eth2near/eth2near-block-relay-rs/src/hand_made_finality_light_client_update.rs
+++ b/eth2near/eth2near-block-relay-rs/src/hand_made_finality_light_client_update.rs
@@ -1,7 +1,9 @@
 use crate::beacon_block_body_merkle_tree::BeaconStateMerkleTree;
 use crate::beacon_rpc_client::BeaconRPCClient;
 use crate::execution_block_proof::ExecutionBlockProof;
-use crate::relay_errors::{ErrorOnUnwrapSignatureBit, MissNextSyncCommittee, MissSyncAggregationError, NoBlockForSlotError};
+use crate::relay_errors::{
+    ErrorOnUnwrapSignatureBit, MissNextSyncCommittee, MissSyncAggregationError, NoBlockForSlotError,
+};
 use eth_types::eth2::{
     FinalizedHeaderUpdate, HeaderUpdate, LightClientUpdate, SignatureBytes, SyncCommittee,
     SyncCommitteeBits, SyncCommitteeUpdate,

--- a/eth2near/eth2near-block-relay-rs/src/hand_made_finality_light_client_update.rs
+++ b/eth2near/eth2near-block-relay-rs/src/hand_made_finality_light_client_update.rs
@@ -333,8 +333,8 @@ mod tests {
     const ATTESTED_SLOT: u64 = 812637;
     const BEACON_ENDPOINT: &str = "https://lodestar-kiln.chainsafe.io";
     const LIGHT_CLIENT_UPDATE_PERIOD: u64 = 99;
-    const TIMEOUT: u64 = 30;
-    const TIMEOUT_STATE: u64 = 1000;
+    const TIMEOUT_SECONDS: u64 = 30;
+    const TIMEOUT_STATE_SECONDS: u64 = 1000;
 
     fn cmp_light_client_updates(
         hand_made_light_client_update: &LightClientUpdate,
@@ -361,7 +361,7 @@ mod tests {
     #[ignore]
     #[test]
     fn test_hand_made_finality_light_client_update() {
-        let beacon_rpc_client = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT, TIMEOUT_STATE);
+        let beacon_rpc_client = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let hand_made_light_client_update =
             HandMadeFinalityLightClientUpdate::get_finality_light_client_update(
                 &beacon_rpc_client,
@@ -383,7 +383,7 @@ mod tests {
 
     #[test]
     fn test_hand_made_finality_light_client_update_from_file() {
-        let beacon_rpc_client = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT, TIMEOUT_STATE);
+        let beacon_rpc_client = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let hand_made_light_client_update =
             HandMadeFinalityLightClientUpdate::get_finality_light_client_update_from_file(
                 &beacon_rpc_client,
@@ -399,7 +399,7 @@ mod tests {
 
     #[test]
     fn test_hand_made_finality_light_client_update_from_file_with_next_sync_committee() {
-        let beacon_rpc_client = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT, TIMEOUT_STATE);
+        let beacon_rpc_client = BeaconRPCClient::new(BEACON_ENDPOINT, TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let hand_made_light_client_update =
             HandMadeFinalityLightClientUpdate::get_light_client_update_from_file_with_next_sync_committee(
                 &beacon_rpc_client,

--- a/eth2near/eth2near-block-relay-rs/src/init_contract.rs
+++ b/eth2near/eth2near-block-relay-rs/src/init_contract.rs
@@ -13,7 +13,11 @@ pub fn init_contract(
 ) -> Result<(), Box<dyn std::error::Error>> {
     info!(target: "relay", "=== Contract initialization ===");
 
-    let beacon_rpc_client = BeaconRPCClient::new(&config.beacon_endpoint);
+    let beacon_rpc_client = BeaconRPCClient::new(
+        &config.beacon_endpoint,
+        config.eth_requests_timeout,
+        config.state_requests_timeout,
+    );
     let eth1_rpc_client = Eth1RPCClient::new(&config.eth1_endpoint);
 
     let start_slot = beacon_rpc_client.get_last_finalized_slot_number().unwrap();

--- a/eth2near/eth2near-block-relay-rs/src/init_contract.rs
+++ b/eth2near/eth2near-block-relay-rs/src/init_contract.rs
@@ -15,8 +15,8 @@ pub fn init_contract(
 
     let beacon_rpc_client = BeaconRPCClient::new(
         &config.beacon_endpoint,
-        config.eth_requests_timeout,
-        config.state_requests_timeout,
+        config.eth_requests_timeout_seconds,
+        config.state_requests_timeout_seconds,
     );
     let eth1_rpc_client = Eth1RPCClient::new(&config.eth1_endpoint);
 

--- a/eth2near/eth2near-block-relay-rs/src/last_slot_searcher.rs
+++ b/eth2near/eth2near-block-relay-rs/src/last_slot_searcher.rs
@@ -447,8 +447,11 @@ mod tests {
     fn test_block_known_on_near() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        let beacon_rpc_client = BeaconRPCClient::new(
+            "https://lodestar-kiln.chainsafe.io",
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS,
+        );
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -499,8 +502,11 @@ mod tests {
     fn test_find_left_non_error_slot() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        let beacon_rpc_client = BeaconRPCClient::new(
+            "https://lodestar-kiln.chainsafe.io",
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS,
+        );
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -574,8 +580,11 @@ mod tests {
     fn test_linear_search_backward() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        let beacon_rpc_client = BeaconRPCClient::new(
+            "https://lodestar-kiln.chainsafe.io",
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS,
+        );
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -619,8 +628,11 @@ mod tests {
     fn test_linear_search_forward() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        let beacon_rpc_client = BeaconRPCClient::new(
+            "https://lodestar-kiln.chainsafe.io",
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS,
+        );
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -674,8 +686,11 @@ mod tests {
     fn test_linear_slot_search() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        let beacon_rpc_client = BeaconRPCClient::new(
+            "https://lodestar-kiln.chainsafe.io",
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS,
+        );
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -745,8 +760,11 @@ mod tests {
     fn test_error_on_connection_problem() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let mut beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        let mut beacon_rpc_client = BeaconRPCClient::new(
+            "https://lodestar-kiln.chainsafe.io",
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS,
+        );
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -762,7 +780,11 @@ mod tests {
             finalized_slot + 2,
         );
 
-        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        beacon_rpc_client = BeaconRPCClient::new(
+            "http://httpstat.us/504/",
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS,
+        );
         last_slot_searcher
             .linear_slot_search(
                 finalized_slot + 1,
@@ -778,8 +800,11 @@ mod tests {
     fn test_binsearch_slot_range() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let mut beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        let mut beacon_rpc_client = BeaconRPCClient::new(
+            "https://lodestar-kiln.chainsafe.io",
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS,
+        );
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -851,7 +876,11 @@ mod tests {
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK);
 
-        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        beacon_rpc_client = BeaconRPCClient::new(
+            "http://httpstat.us/504/",
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS,
+        );
         if last_slot_searcher
             .binsearch_slot_range(
                 eth_client_contract
@@ -872,8 +901,11 @@ mod tests {
     fn test_binsearch_slot_forward() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let mut beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        let mut beacon_rpc_client = BeaconRPCClient::new(
+            "https://lodestar-kiln.chainsafe.io",
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS,
+        );
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -946,7 +978,11 @@ mod tests {
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK);
 
-        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        beacon_rpc_client = BeaconRPCClient::new(
+            "http://httpstat.us/504/",
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS,
+        );
         if last_slot_searcher
             .binsearch_slot_forward(
                 eth_client_contract
@@ -967,8 +1003,11 @@ mod tests {
     fn test_binsearch_slot_search() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let mut beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        let mut beacon_rpc_client = BeaconRPCClient::new(
+            "https://lodestar-kiln.chainsafe.io",
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS,
+        );
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -1051,7 +1090,11 @@ mod tests {
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK - 1);
 
-        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        beacon_rpc_client = BeaconRPCClient::new(
+            "http://httpstat.us/504/",
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS,
+        );
         if last_slot_searcher
             .binary_slot_search(
                 finalized_slot + 1,
@@ -1070,8 +1113,11 @@ mod tests {
     fn test_get_last_slot_binsearch() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let mut beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        let mut beacon_rpc_client = BeaconRPCClient::new(
+            "https://lodestar-kiln.chainsafe.io",
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS,
+        );
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let mut last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -1112,7 +1158,11 @@ mod tests {
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK);
 
-        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        beacon_rpc_client = BeaconRPCClient::new(
+            "http://httpstat.us/504/",
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS,
+        );
         if last_slot_searcher
             .get_last_slot(
                 RIGHT_BOUND_IN_SLOT_SEARCH,
@@ -1129,8 +1179,11 @@ mod tests {
     fn test_get_last_slot_linearsearch() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let mut beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        let mut beacon_rpc_client = BeaconRPCClient::new(
+            "https://lodestar-kiln.chainsafe.io",
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS,
+        );
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let mut last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -1172,7 +1225,11 @@ mod tests {
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK);
 
-        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+        beacon_rpc_client = BeaconRPCClient::new(
+            "http://httpstat.us/504/",
+            TIMEOUT_SECONDS,
+            TIMEOUT_STATE_SECONDS,
+        );
         if last_slot_searcher
             .get_last_slot(
                 RIGHT_BOUND_IN_SLOT_SEARCH,

--- a/eth2near/eth2near-block-relay-rs/src/last_slot_searcher.rs
+++ b/eth2near/eth2near-block-relay-rs/src/last_slot_searcher.rs
@@ -409,6 +409,8 @@ mod tests {
     const FIRST_SLOT: u64 = 1099360;
     const SLOT_WITHOUT_BLOCK: u64 = 1099364;
     const RIGHT_BOUND_IN_SLOT_SEARCH: u64 = 1099500;
+    const TIMEOUT: u64 = 30;
+    const TIMEOUT_STATE: u64 = 1000;
 
     fn get_execution_block_by_slot(
         slot: u64,
@@ -445,7 +447,8 @@ mod tests {
     fn test_block_known_on_near() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let beacon_rpc_client = BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io");
+        let beacon_rpc_client =
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -496,7 +499,8 @@ mod tests {
     fn test_find_left_non_error_slot() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let beacon_rpc_client = BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io");
+        let beacon_rpc_client =
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -570,7 +574,8 @@ mod tests {
     fn test_linear_search_backward() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let beacon_rpc_client = BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io");
+        let beacon_rpc_client =
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -614,7 +619,8 @@ mod tests {
     fn test_linear_search_forward() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let beacon_rpc_client = BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io");
+        let beacon_rpc_client =
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -668,7 +674,8 @@ mod tests {
     fn test_linear_slot_search() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let beacon_rpc_client = BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io");
+        let beacon_rpc_client =
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -738,7 +745,8 @@ mod tests {
     fn test_error_on_connection_problem() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let mut beacon_rpc_client = BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io");
+        let mut beacon_rpc_client =
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -754,7 +762,7 @@ mod tests {
             finalized_slot + 2,
         );
 
-        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/");
+        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT, TIMEOUT_STATE);
         last_slot_searcher
             .linear_slot_search(
                 finalized_slot + 1,
@@ -770,7 +778,8 @@ mod tests {
     fn test_binsearch_slot_range() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let mut beacon_rpc_client = BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io");
+        let mut beacon_rpc_client =
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -842,7 +851,7 @@ mod tests {
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK);
 
-        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/");
+        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT, TIMEOUT_STATE);
         if last_slot_searcher
             .binsearch_slot_range(
                 eth_client_contract
@@ -863,7 +872,8 @@ mod tests {
     fn test_binsearch_slot_forward() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let mut beacon_rpc_client = BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io");
+        let mut beacon_rpc_client =
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -936,7 +946,7 @@ mod tests {
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK);
 
-        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/");
+        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT, TIMEOUT_STATE);
         if last_slot_searcher
             .binsearch_slot_forward(
                 eth_client_contract
@@ -957,7 +967,8 @@ mod tests {
     fn test_binsearch_slot_search() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let mut beacon_rpc_client = BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io");
+        let mut beacon_rpc_client =
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -1040,7 +1051,7 @@ mod tests {
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK - 1);
 
-        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/");
+        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT, TIMEOUT_STATE);
         if last_slot_searcher
             .binary_slot_search(
                 finalized_slot + 1,
@@ -1059,7 +1070,8 @@ mod tests {
     fn test_get_last_slot_binsearch() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let mut beacon_rpc_client = BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io");
+        let mut beacon_rpc_client =
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let mut last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -1100,7 +1112,7 @@ mod tests {
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK);
 
-        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/");
+        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT, TIMEOUT_STATE);
         if last_slot_searcher
             .get_last_slot(
                 RIGHT_BOUND_IN_SLOT_SEARCH,
@@ -1117,7 +1129,8 @@ mod tests {
     fn test_get_last_slot_linearsearch() {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
-        let mut beacon_rpc_client = BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io");
+        let mut beacon_rpc_client =
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let mut last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -1159,7 +1172,7 @@ mod tests {
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK);
 
-        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/");
+        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT, TIMEOUT_STATE);
         if last_slot_searcher
             .get_last_slot(
                 RIGHT_BOUND_IN_SLOT_SEARCH,

--- a/eth2near/eth2near-block-relay-rs/src/last_slot_searcher.rs
+++ b/eth2near/eth2near-block-relay-rs/src/last_slot_searcher.rs
@@ -409,8 +409,8 @@ mod tests {
     const FIRST_SLOT: u64 = 1099360;
     const SLOT_WITHOUT_BLOCK: u64 = 1099364;
     const RIGHT_BOUND_IN_SLOT_SEARCH: u64 = 1099500;
-    const TIMEOUT: u64 = 30;
-    const TIMEOUT_STATE: u64 = 1000;
+    const TIMEOUT_SECONDS: u64 = 30;
+    const TIMEOUT_STATE_SECONDS: u64 = 1000;
 
     fn get_execution_block_by_slot(
         slot: u64,
@@ -448,7 +448,7 @@ mod tests {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
         let beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -500,7 +500,7 @@ mod tests {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
         let beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -575,7 +575,7 @@ mod tests {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
         let beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -620,7 +620,7 @@ mod tests {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
         let beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -675,7 +675,7 @@ mod tests {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
         let beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -746,7 +746,7 @@ mod tests {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
         let mut beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -762,7 +762,7 @@ mod tests {
             finalized_slot + 2,
         );
 
-        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT, TIMEOUT_STATE);
+        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         last_slot_searcher
             .linear_slot_search(
                 finalized_slot + 1,
@@ -779,7 +779,7 @@ mod tests {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
         let mut beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -851,7 +851,7 @@ mod tests {
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK);
 
-        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT, TIMEOUT_STATE);
+        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         if last_slot_searcher
             .binsearch_slot_range(
                 eth_client_contract
@@ -873,7 +873,7 @@ mod tests {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
         let mut beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -946,7 +946,7 @@ mod tests {
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK);
 
-        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT, TIMEOUT_STATE);
+        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         if last_slot_searcher
             .binsearch_slot_forward(
                 eth_client_contract
@@ -968,7 +968,7 @@ mod tests {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
         let mut beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -1051,7 +1051,7 @@ mod tests {
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK - 1);
 
-        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT, TIMEOUT_STATE);
+        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         if last_slot_searcher
             .binary_slot_search(
                 finalized_slot + 1,
@@ -1071,7 +1071,7 @@ mod tests {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
         let mut beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let mut last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -1112,7 +1112,7 @@ mod tests {
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK);
 
-        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT, TIMEOUT_STATE);
+        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         if last_slot_searcher
             .get_last_slot(
                 RIGHT_BOUND_IN_SLOT_SEARCH,
@@ -1130,7 +1130,7 @@ mod tests {
         let mut eth_client_contract = get_client_contract(true);
         eth_client_contract.register_submitter().unwrap();
         let mut beacon_rpc_client =
-            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
+            BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
         let mut last_slot_searcher = LastSlotSearcher::new(true);
 
@@ -1172,7 +1172,7 @@ mod tests {
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK);
 
-        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT, TIMEOUT_STATE);
+        beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
         if last_slot_searcher
             .get_last_slot(
                 RIGHT_BOUND_IN_SLOT_SEARCH,

--- a/eth2near/eth2near-block-relay-rs/src/last_slot_searcher.rs
+++ b/eth2near/eth2near-block-relay-rs/src/last_slot_searcher.rs
@@ -410,7 +410,6 @@ mod tests {
     const SLOT_WITHOUT_BLOCK: u64 = 1099364;
     const RIGHT_BOUND_IN_SLOT_SEARCH: u64 = 1099500;
 
-
     fn get_execution_block_by_slot(
         slot: u64,
         beacon_rpc_client: &BeaconRPCClient,
@@ -834,7 +833,12 @@ mod tests {
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK - 1);
 
         let last_block_on_near = last_slot_searcher
-            .binsearch_slot_range(SLOT_WITHOUT_BLOCK, RIGHT_BOUND_IN_SLOT_SEARCH, &beacon_rpc_client, &eth_client_contract)
+            .binsearch_slot_range(
+                SLOT_WITHOUT_BLOCK,
+                RIGHT_BOUND_IN_SLOT_SEARCH,
+                &beacon_rpc_client,
+                &eth_client_contract,
+            )
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK);
 
@@ -923,7 +927,12 @@ mod tests {
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK - 1);
 
         let last_block_on_near = last_slot_searcher
-            .binsearch_slot_forward(SLOT_WITHOUT_BLOCK, RIGHT_BOUND_IN_SLOT_SEARCH, &beacon_rpc_client, &eth_client_contract)
+            .binsearch_slot_forward(
+                SLOT_WITHOUT_BLOCK,
+                RIGHT_BOUND_IN_SLOT_SEARCH,
+                &beacon_rpc_client,
+                &eth_client_contract,
+            )
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK);
 
@@ -1066,7 +1075,11 @@ mod tests {
         );
 
         let last_block_on_near = last_slot_searcher
-            .get_last_slot(RIGHT_BOUND_IN_SLOT_SEARCH, &beacon_rpc_client, &eth_client_contract)
+            .get_last_slot(
+                RIGHT_BOUND_IN_SLOT_SEARCH,
+                &beacon_rpc_client,
+                &eth_client_contract,
+            )
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK - 2);
 
@@ -1079,13 +1092,21 @@ mod tests {
         );
 
         let last_block_on_near = last_slot_searcher
-            .get_last_slot(RIGHT_BOUND_IN_SLOT_SEARCH, &beacon_rpc_client, &eth_client_contract)
+            .get_last_slot(
+                RIGHT_BOUND_IN_SLOT_SEARCH,
+                &beacon_rpc_client,
+                &eth_client_contract,
+            )
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK);
 
         beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/");
         if last_slot_searcher
-            .get_last_slot(RIGHT_BOUND_IN_SLOT_SEARCH, &beacon_rpc_client, &eth_client_contract)
+            .get_last_slot(
+                RIGHT_BOUND_IN_SLOT_SEARCH,
+                &beacon_rpc_client,
+                &eth_client_contract,
+            )
             .is_ok()
         {
             panic!("binarysearch returns result in unworking network");
@@ -1113,7 +1134,11 @@ mod tests {
         );
 
         let last_block_on_near = last_slot_searcher
-            .get_last_slot(RIGHT_BOUND_IN_SLOT_SEARCH, &beacon_rpc_client, &eth_client_contract)
+            .get_last_slot(
+                RIGHT_BOUND_IN_SLOT_SEARCH,
+                &beacon_rpc_client,
+                &eth_client_contract,
+            )
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK - 2);
 
@@ -1126,13 +1151,21 @@ mod tests {
         );
 
         let last_block_on_near = last_slot_searcher
-            .get_last_slot(RIGHT_BOUND_IN_SLOT_SEARCH, &beacon_rpc_client, &eth_client_contract)
+            .get_last_slot(
+                RIGHT_BOUND_IN_SLOT_SEARCH,
+                &beacon_rpc_client,
+                &eth_client_contract,
+            )
             .unwrap();
         assert_eq!(last_block_on_near, SLOT_WITHOUT_BLOCK);
 
         beacon_rpc_client = BeaconRPCClient::new("http://httpstat.us/504/");
         if last_slot_searcher
-            .get_last_slot(RIGHT_BOUND_IN_SLOT_SEARCH, &beacon_rpc_client, &eth_client_contract)
+            .get_last_slot(
+                RIGHT_BOUND_IN_SLOT_SEARCH,
+                &beacon_rpc_client,
+                &eth_client_contract,
+            )
             .is_ok()
         {
             panic!("binarysearch returns result in unworking network");

--- a/eth2near/eth2near-block-relay-rs/src/lib.rs
+++ b/eth2near/eth2near-block-relay-rs/src/lib.rs
@@ -8,8 +8,8 @@ pub mod hand_made_finality_light_client_update;
 pub mod init_contract;
 pub mod last_slot_searcher;
 pub mod logger;
-pub mod relay_errors;
 pub mod near_rpc_client;
+pub mod relay_errors;
 
 #[cfg(test)]
 pub mod test_utils;

--- a/eth2near/eth2near-block-relay-rs/src/lib.rs
+++ b/eth2near/eth2near-block-relay-rs/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate core;
+
 pub mod beacon_block_body_merkle_tree;
 pub mod beacon_rpc_client;
 pub mod config;
@@ -9,6 +11,7 @@ pub mod init_contract;
 pub mod last_slot_searcher;
 pub mod logger;
 pub mod relay_errors;
+pub mod near_rpc_client;
 
 #[cfg(test)]
 pub mod test_utils;

--- a/eth2near/eth2near-block-relay-rs/src/lib.rs
+++ b/eth2near/eth2near-block-relay-rs/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate core;
-
 pub mod beacon_block_body_merkle_tree;
 pub mod beacon_rpc_client;
 pub mod config;

--- a/eth2near/eth2near-block-relay-rs/src/main.rs
+++ b/eth2near/eth2near-block-relay-rs/src/main.rs
@@ -32,11 +32,11 @@ struct Arguments {
     /// Log level (trace, debug, info, warn, error)
     log_level: String,
 
-    #[clap(long, action = ArgAction::SetTrue)]
+    #[clap(long, action = ArgAction::SetTrue, default_value_t = true)]
     /// Enable binary search for last slot ETH block on NEAR
     enable_binary_search: bool,
 
-    #[clap(long, action = ArgAction::SetTrue)]
+    #[clap(long, action = ArgAction::SetTrue, default_value_t = true)]
     /// Submit to ETH2 Client only blocks before last finalized block on NEAR
     submit_only_finalized_blocks: bool,
 }
@@ -106,16 +106,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if args.init_contract {
         let mut eth_client_contract = EthClientContract::new(get_eth_contract_wrapper(&config));
         init_contract(&config, &mut eth_client_contract).unwrap();
+    } else {
+        let mut eth2near_relay = Eth2NearRelay::init(
+            &config,
+            get_eth_client_contract(&config),
+            args.enable_binary_search,
+            args.register_relay,
+            args.submit_only_finalized_blocks,
+        );
+
+        eth2near_relay.run(None);
     }
 
-    let mut eth2near_relay = Eth2NearRelay::init(
-        &config,
-        get_eth_client_contract(&config),
-        args.enable_binary_search,
-        args.register_relay,
-        args.submit_only_finalized_blocks,
-    );
-
-    eth2near_relay.run(None);
     Ok(())
 }

--- a/eth2near/eth2near-block-relay-rs/src/main.rs
+++ b/eth2near/eth2near-block-relay-rs/src/main.rs
@@ -35,6 +35,10 @@ struct Arguments {
     #[clap(long, action = ArgAction::SetTrue)]
     /// Enable binary search for last slot ETH block on NEAR
     enable_binary_search: bool,
+
+    #[clap(long, action = ArgAction::SetTrue)]
+    /// Submit to ETH2 Client only blocks before last finalized block on NEAR
+    submit_only_finalized_blocks: bool,
 }
 
 fn get_eth_contract_wrapper(config: &Config) -> Box<dyn ContractWrapper> {
@@ -109,6 +113,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         get_eth_client_contract(&config),
         args.enable_binary_search,
         args.register_relay,
+        args.submit_only_finalized_blocks,
     );
 
     eth2near_relay.run(None);

--- a/eth2near/eth2near-block-relay-rs/src/main.rs
+++ b/eth2near/eth2near-block-relay-rs/src/main.rs
@@ -32,11 +32,11 @@ struct Arguments {
     /// Log level (trace, debug, info, warn, error)
     log_level: String,
 
-    #[clap(long, action = ArgAction::SetTrue, default_value_t = true)]
+    #[clap(long, action = ArgAction::Set, default_value_t = true)]
     /// Enable binary search for last slot ETH block on NEAR
     enable_binary_search: bool,
 
-    #[clap(long, action = ArgAction::SetTrue, default_value_t = true)]
+    #[clap(long, action = ArgAction::Set, default_value_t = true)]
     /// Submit to ETH2 Client only blocks before last finalized block on NEAR
     submit_only_finalized_blocks: bool,
 }

--- a/eth2near/eth2near-block-relay-rs/src/near_rpc_client.rs
+++ b/eth2near/eth2near-block-relay-rs/src/near_rpc_client.rs
@@ -36,7 +36,7 @@ impl NearRPCClient {
 
         let val: Value = serde_json::from_str(&res)?;
 
-        return Ok(val["result"].is_object());
+        Ok(val["result"].is_object())
     }
 
     pub fn is_syncing(&self) -> Result<bool, Box<dyn Error>> {
@@ -60,7 +60,7 @@ impl NearRPCClient {
             return Ok(is_sync);
         }
 
-        return Ok(true);
+        Ok(true)
     }
 }
 

--- a/eth2near/eth2near-block-relay-rs/src/near_rpc_client.rs
+++ b/eth2near/eth2near-block-relay-rs/src/near_rpc_client.rs
@@ -36,7 +36,7 @@ impl NearRPCClient {
 
         let val: Value = serde_json::from_str(&res)?;
 
-        return Ok(val["result"].is_object())
+        return Ok(val["result"].is_object());
     }
 
     pub fn is_syncing(&self) -> Result<bool, Box<dyn Error>> {

--- a/eth2near/eth2near-block-relay-rs/src/near_rpc_client.rs
+++ b/eth2near/eth2near-block-relay-rs/src/near_rpc_client.rs
@@ -1,0 +1,70 @@
+use reqwest::blocking::Client;
+use serde_json::{json, Value};
+use std::error::Error;
+
+pub struct NearRPCClient {
+    endpoint_url: String,
+    client: Client,
+}
+
+impl NearRPCClient {
+    pub fn new(endpoint_url: &str) -> Self {
+        Self {
+            endpoint_url: endpoint_url.to_string(),
+            client: reqwest::blocking::Client::new(),
+        }
+    }
+
+    pub fn check_account_exists(&self, account_id: &str) -> Result<bool, Box<dyn Error>> {
+        let json_value = json!({
+            "id": "dontcare",
+            "jsonrpc": "2.0",
+            "method": "query",
+            "params": {
+                "request_type": "view_account",
+                "finality": "final",
+                "account_id": account_id,
+            }
+        });
+
+        let res = self
+            .client
+            .post(&self.endpoint_url)
+            .json(&json_value)
+            .send()?
+            .text()?;
+
+        let val: Value = serde_json::from_str(&res)?;
+
+        return Ok(val["result"].is_object())
+    }
+
+    pub fn is_syncing(&self) -> Result<bool, Box<dyn Error>> {
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::near_rpc_client::NearRPCClient;
+
+    const NEAR_ENDPOINT: &str = "https://rpc.testnet.near.org";
+
+    #[test]
+    fn test_check_account_id() {
+        let near_rpc_client = NearRPCClient::new(NEAR_ENDPOINT);
+        assert!(near_rpc_client
+            .check_account_exists("olga24912_3.testnet")
+            .unwrap());
+
+        assert!(!near_rpc_client
+            .check_account_exists("dadadadasdsa.testnet")
+            .unwrap());
+    }
+
+    #[test]
+    fn test_is_syncing() {
+        let rpc_client = NearRPCClient::new(NEAR_ENDPOINT);
+        assert!(!rpc_client.is_syncing().unwrap());
+    }
+}

--- a/eth2near/eth2near-block-relay-rs/src/near_rpc_client.rs
+++ b/eth2near/eth2near-block-relay-rs/src/near_rpc_client.rs
@@ -40,14 +40,33 @@ impl NearRPCClient {
     }
 
     pub fn is_syncing(&self) -> Result<bool, Box<dyn Error>> {
-        Ok(true)
+        let json_value = json!({
+            "id": "dontcare",
+            "jsonrpc": "2.0",
+            "method": "status",
+            "params": []
+        });
+
+        let res = self
+            .client
+            .post(&self.endpoint_url)
+            .json(&json_value)
+            .send()?
+            .text()?;
+
+        let val: Value = serde_json::from_str(&res)?;
+
+        if let Some(is_sync) = val["result"]["sync_info"]["syncing"].as_bool() {
+            return Ok(is_sync);
+        }
+
+        return Ok(true);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::near_rpc_client::NearRPCClient;
-
     const NEAR_ENDPOINT: &str = "https://rpc.testnet.near.org";
 
     #[test]

--- a/eth2near/eth2near-block-relay-rs/src/relay_errors.rs
+++ b/eth2near/eth2near-block-relay-rs/src/relay_errors.rs
@@ -94,7 +94,7 @@ impl Error for NoBlockForSlotError {}
 
 #[derive(Debug)]
 pub struct FailOnGettingJson {
-    pub response: String
+    pub response: String,
 }
 
 impl Display for FailOnGettingJson {

--- a/eth2near/eth2near-block-relay-rs/src/test_utils.rs
+++ b/eth2near/eth2near-block-relay-rs/src/test_utils.rs
@@ -222,7 +222,7 @@ pub fn get_relay(enable_binsearch: bool, from_file: bool) -> Eth2NearRelay {
         get_client_contract(from_file),
         enable_binsearch,
         true,
-        false
+        false,
     )
 }
 
@@ -245,7 +245,7 @@ pub fn get_relay_with_update_from_file(
         get_client_contract(from_file),
         enable_binsearch,
         true,
-        false
+        false,
     )
 }
 
@@ -263,6 +263,6 @@ pub fn get_relay_from_slot(enable_binsearch: bool, slot: u64) -> Eth2NearRelay {
         Box::new(eth_client_contract),
         enable_binsearch,
         true,
-        false
+        false,
     )
 }

--- a/eth2near/eth2near-block-relay-rs/src/test_utils.rs
+++ b/eth2near/eth2near-block-relay-rs/src/test_utils.rs
@@ -222,6 +222,7 @@ pub fn get_relay(enable_binsearch: bool, from_file: bool) -> Eth2NearRelay {
         get_client_contract(from_file),
         enable_binsearch,
         true,
+        false
     )
 }
 
@@ -244,6 +245,7 @@ pub fn get_relay_with_update_from_file(
         get_client_contract(from_file),
         enable_binsearch,
         true,
+        false
     )
 }
 
@@ -261,5 +263,6 @@ pub fn get_relay_from_slot(enable_binsearch: bool, slot: u64) -> Eth2NearRelay {
         Box::new(eth_client_contract),
         enable_binsearch,
         true,
+        false
     )
 }

--- a/eth2near/eth2near-block-relay-rs/src/test_utils.rs
+++ b/eth2near/eth2near-block-relay-rs/src/test_utils.rs
@@ -93,8 +93,8 @@ pub fn init_contract_from_specific_slot(
     const PATH_TO_NEXT_SYNC_COMMITTEE: &str =
         "../contract_wrapper/data/next_sync_committee_kiln_period_134.json";
     const NETWORK: &str = "kiln";
-    const TIMEOUT: u64 = 30;
-    const TIMEOUT_STATE: u64 = 1000;
+    const TIMEOUT_SECONDS: u64 = 30;
+    const TIMEOUT_STATE_SECONDS: u64 = 1000;
 
     let current_sync_committee: SyncCommittee = serde_json::from_str(
         &std::fs::read_to_string(PATH_TO_CURRENT_SYNC_COMMITTEE).expect("Unable to read file"),
@@ -105,7 +105,7 @@ pub fn init_contract_from_specific_slot(
     )
     .unwrap();
 
-    let beacon_rpc_client = BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
+    let beacon_rpc_client = BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
     let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
 
     let finality_header = beacon_rpc_client
@@ -200,8 +200,8 @@ fn get_config() -> Config {
         output_dir: None,
         path_to_attested_state: None,
         path_to_finality_state: None,
-        eth_requests_timeout: 30,
-        state_requests_timeout: 1000,
+        eth_requests_timeout_seconds: 30,
+        state_requests_timeout_seconds: 1000,
     }
 }
 

--- a/eth2near/eth2near-block-relay-rs/src/test_utils.rs
+++ b/eth2near/eth2near-block-relay-rs/src/test_utils.rs
@@ -93,6 +93,8 @@ pub fn init_contract_from_specific_slot(
     const PATH_TO_NEXT_SYNC_COMMITTEE: &str =
         "../contract_wrapper/data/next_sync_committee_kiln_period_134.json";
     const NETWORK: &str = "kiln";
+    const TIMEOUT: u64 = 30;
+    const TIMEOUT_STATE: u64 = 1000;
 
     let current_sync_committee: SyncCommittee = serde_json::from_str(
         &std::fs::read_to_string(PATH_TO_CURRENT_SYNC_COMMITTEE).expect("Unable to read file"),
@@ -103,7 +105,7 @@ pub fn init_contract_from_specific_slot(
     )
     .unwrap();
 
-    let beacon_rpc_client = BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io");
+    let beacon_rpc_client = BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT, TIMEOUT_STATE);
     let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
 
     let finality_header = beacon_rpc_client
@@ -198,6 +200,8 @@ fn get_config() -> Config {
         output_dir: None,
         path_to_attested_state: None,
         path_to_finality_state: None,
+        eth_requests_timeout: 30,
+        state_requests_timeout: 1000,
     }
 }
 

--- a/eth2near/eth2near-block-relay-rs/src/test_utils.rs
+++ b/eth2near/eth2near-block-relay-rs/src/test_utils.rs
@@ -105,7 +105,11 @@ pub fn init_contract_from_specific_slot(
     )
     .unwrap();
 
-    let beacon_rpc_client = BeaconRPCClient::new("https://lodestar-kiln.chainsafe.io", TIMEOUT_SECONDS, TIMEOUT_STATE_SECONDS);
+    let beacon_rpc_client = BeaconRPCClient::new(
+        "https://lodestar-kiln.chainsafe.io",
+        TIMEOUT_SECONDS,
+        TIMEOUT_STATE_SECONDS,
+    );
     let eth1_rpc_client = Eth1RPCClient::new("https://rpc.kiln.themerge.dev");
 
     let finality_header = beacon_rpc_client


### PR DESCRIPTION
* handle submission of zero headers
* timeout on submission headers to NEAR
* move timeout for fetching beacon states/blocks into configs
* check that Beacon/ETH1/NEAR networks are sync
* check config input format
* submit only finalized blocks mode
* sleep between loops iterations
* use correct sync committee between periods for signature verification
* don't subtract u64 
* find signature slot with enough sync committee bits sum
* check attestations.len > 0
* change beacon API for new one