### PR TITLE
Eth2-to-Near-relay: fix sending light client update

### DIFF
--- a/eth2near/contract_wrapper/src/contract_wrapper_trait.rs
+++ b/eth2near/contract_wrapper/src/contract_wrapper_trait.rs
@@ -5,6 +5,8 @@ use near_sdk::{Balance, Gas};
 pub trait ContractWrapper {
     fn get_account_id(&self) -> AccountId;
 
+    fn get_signer_account_id(&self) -> AccountId;
+
     fn call_view_function(
         &self,
         method_name: String,

--- a/eth2near/contract_wrapper/src/dao_contract.rs
+++ b/eth2near/contract_wrapper/src/dao_contract.rs
@@ -9,7 +9,7 @@ use std::error::Error;
 
 use crate::contract_wrapper_trait::ContractWrapper;
 pub struct DAOContract {
-    contract_wrapper: Box<dyn ContractWrapper>,
+    pub contract_wrapper: Box<dyn ContractWrapper>,
 }
 
 impl DAOContract {
@@ -93,7 +93,7 @@ impl DAOContract {
         let update_hash = near_primitives::hash::hash(&raw_update);
         let args = Base64VecU8::from(raw_update);
 
-        const GAS_FOR_SUBMIT_LIGHT_CLIENT_UPDATE: u64 = 250 * Gas::ONE_TERA.0;
+        const GAS_FOR_SUBMIT_LIGHT_CLIENT_UPDATE: u64 = 270 * Gas::ONE_TERA.0;
         let action = ActionCall {
             method_name: "submit_beacon_chain_light_client_update".to_string(),
             args,

--- a/eth2near/contract_wrapper/src/near_contract_wrapper.rs
+++ b/eth2near/contract_wrapper/src/near_contract_wrapper.rs
@@ -1,4 +1,5 @@
 use crate::contract_wrapper_trait::ContractWrapper;
+use crate::utils::trim_quotes;
 use near_crypto::InMemorySigner;
 use near_jsonrpc_client::{methods, JsonRpcClient};
 use near_jsonrpc_primitives::types::query::QueryResponseKind;
@@ -11,7 +12,6 @@ use std::error::Error;
 use std::string::String;
 use std::vec::Vec;
 use tokio::runtime::Runtime;
-use crate::utils::trim_quotes;
 
 pub const MAX_GAS: Gas = Gas(Gas::ONE_TERA.0 * 300);
 
@@ -66,6 +66,10 @@ impl NearContractWrapper {
 impl ContractWrapper for NearContractWrapper {
     fn get_account_id(&self) -> AccountId {
         self.contract_account.clone()
+    }
+
+    fn get_signer_account_id(&self) -> AccountId {
+        self.signer.account_id.clone()
     }
 
     fn call_view_function(

--- a/eth2near/contract_wrapper/src/sandbox_contract_wrapper.rs
+++ b/eth2near/contract_wrapper/src/sandbox_contract_wrapper.rs
@@ -124,25 +124,31 @@ impl ContractWrapper for SandboxContractWrapper {
     ) -> Result<FinalExecutionOutcomeView, Box<dyn Error>> {
         let rt = Runtime::new()?;
 
-        Ok(Self::get_final_execution_outcome_view_from_call_execution_details(
-            rt.block_on(
-                self.signer_account
-                    .call(&self.worker, self.contract.id(), &method_name)
-                    .deposit(match deposit {
-                        Some(deposit) => deposit,
-                        None => 0,
-                    })
-                    .gas(match gas {
-                        Some(gas) => gas.0,
-                        None => MAX_GAS.0,
-                    })
-                    .args(args)
-                    .transact(),
-            )?,
-        ))
+        Ok(
+            Self::get_final_execution_outcome_view_from_call_execution_details(
+                rt.block_on(
+                    self.signer_account
+                        .call(&self.worker, self.contract.id(), &method_name)
+                        .deposit(match deposit {
+                            Some(deposit) => deposit,
+                            None => 0,
+                        })
+                        .gas(match gas {
+                            Some(gas) => gas.0,
+                            None => MAX_GAS.0,
+                        })
+                        .args(args)
+                        .transact(),
+                )?,
+            ),
+        )
     }
 
     fn get_account_id(&self) -> AccountId {
         self.contract.id().clone()
+    }
+
+    fn get_signer_account_id(&self) -> AccountId {
+        self.signer_account.id().to_string().parse().unwrap()
     }
 }


### PR DESCRIPTION
* Return error on sending light client update proposal if it already has been submitted.
* Increase the gas to execute the light client update proposal from 250 to 270.
* Apply cargo fmt