### PR TITLE
Eth2-to-Near-relay: fix bug on relayer hanging up because of RPC result

### DIFF
--- a/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
+++ b/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
@@ -172,8 +172,9 @@ impl Eth2NearRelay {
         LAST_FINALIZED_ETH_SLOT_ON_NEAR
             .inc_by(max(0, last_finalized_slot_on_near as i64 - LAST_FINALIZED_ETH_SLOT_ON_NEAR.get()));
 
-        let last_block_number = self.beacon_rpc_client.get_block_number_for_slot(Slot::new(last_finalized_slot_on_near))?;
-        CHAIN_FINALIZED_EXECUTION_BLOCK_HEIGHT_ON_NEAR.inc_by(max(0, last_block_number as i64 - CHAIN_FINALIZED_EXECUTION_BLOCK_HEIGHT_ON_NEAR.get()));
+        if let Ok(last_block_number) = self.beacon_rpc_client.get_block_number_for_slot(Slot::new(last_finalized_slot_on_near)) {
+            CHAIN_FINALIZED_EXECUTION_BLOCK_HEIGHT_ON_NEAR.inc_by(max(0, last_block_number as i64 - CHAIN_FINALIZED_EXECUTION_BLOCK_HEIGHT_ON_NEAR.get()));
+        }
 
         Ok(last_finalized_slot_on_near)
     }
@@ -186,8 +187,9 @@ impl Eth2NearRelay {
         LAST_FINALIZED_ETH_SLOT
             .inc_by(max(0,last_finalized_slot_on_eth as i64 - LAST_FINALIZED_ETH_SLOT.get()));
 
-        let last_block_number = self.beacon_rpc_client.get_block_number_for_slot(Slot::new(last_finalized_slot_on_eth))?;
-        CHAIN_FINALIZED_EXECUTION_BLOCK_HEIGHT_ON_ETH.inc_by(max(0, last_block_number as i64 - CHAIN_FINALIZED_EXECUTION_BLOCK_HEIGHT_ON_ETH.get()));
+        if let Ok(last_block_number) = self.beacon_rpc_client.get_block_number_for_slot(Slot::new(last_finalized_slot_on_eth)) {
+            CHAIN_FINALIZED_EXECUTION_BLOCK_HEIGHT_ON_ETH.inc_by(max(0, last_block_number as i64 - CHAIN_FINALIZED_EXECUTION_BLOCK_HEIGHT_ON_ETH.get()));
+        }
 
         Ok(last_finalized_slot_on_eth)
     }

--- a/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
+++ b/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
@@ -139,8 +139,9 @@ impl Eth2NearRelay {
         LAST_ETH_SLOT.inc_by(max(0, last_eth2_slot as i64 - LAST_ETH_SLOT.get()));
         info!(target: "relay", "Last slot on ETH = {}", last_eth2_slot);
 
-        let last_block_number = self.beacon_rpc_client.get_block_number_for_slot(Slot::new(last_eth2_slot))?;
-        CHAIN_EXECUTION_BLOCK_HEIGHT_ON_ETH.inc_by(max(0, last_block_number as i64 - CHAIN_EXECUTION_BLOCK_HEIGHT_ON_ETH.get()));
+        if let Ok(last_block_number) = self.beacon_rpc_client.get_block_number_for_slot(Slot::new(last_eth2_slot)) {
+            CHAIN_EXECUTION_BLOCK_HEIGHT_ON_ETH.inc_by(max(0, last_block_number as i64 - CHAIN_EXECUTION_BLOCK_HEIGHT_ON_ETH.get()));
+        }
 
         return if self.submit_only_finalized_blocks {
             Ok(self.beacon_rpc_client.get_last_finalized_slot_number()?.as_u64())
@@ -159,8 +160,9 @@ impl Eth2NearRelay {
         LAST_ETH_SLOT_ON_NEAR
             .inc_by(max(0,last_eth2_slot_on_near as i64 - LAST_ETH_SLOT_ON_NEAR.get()));
 
-        let last_block_number = self.beacon_rpc_client.get_block_number_for_slot(Slot::new(last_eth2_slot_on_near))?;
-        CHAIN_EXECUTION_BLOCK_HEIGHT_ON_NEAR.inc_by(max(0, last_block_number as i64 - CHAIN_EXECUTION_BLOCK_HEIGHT_ON_NEAR.get()));
+        if let Ok(last_block_number) = self.beacon_rpc_client.get_block_number_for_slot(Slot::new(last_eth2_slot_on_near)) {
+            CHAIN_EXECUTION_BLOCK_HEIGHT_ON_NEAR.inc_by(max(0, last_block_number as i64 - CHAIN_EXECUTION_BLOCK_HEIGHT_ON_NEAR.get()));
+        }
 
         return Ok(last_eth2_slot_on_near);
     }


### PR DESCRIPTION
* Bug fix: the last slot on NEAR can contain no blocks, and in this case, "get_block_number_for_slot" returns an error, and the relay will hang up.