### PR TITLE
Eth2-to-Near-relay: remove limits for search non empty beacon block header

### DIFF
--- a/eth2near/eth2near-block-relay-rs/src/beacon_rpc_client.rs
+++ b/eth2near/eth2near-block-relay-rs/src/beacon_rpc_client.rs
@@ -482,22 +482,22 @@ impl BeaconRPCClient {
         &self,
         start_slot: u64,
     ) -> Result<types::BeaconBlockHeader, Box<dyn Error>> {
-        const CHECK_SLOTS_FORWARD_LIMIT: u64 = 32;
+        let finalized_slot = self.get_last_finalized_slot_number()?.as_u64();
 
-        let mut slot = start_slot;
-        for _ in 0..CHECK_SLOTS_FORWARD_LIMIT {
-            if let Ok(beacon_block_body) =
-                self.get_beacon_block_header_for_block_id(&format!("{}", slot))
-            {
-                return Ok(beacon_block_body);
+        for slot in start_slot..finalized_slot {
+            match self.get_beacon_block_header_for_block_id(&format!("{}", slot)) {
+                Ok(beacon_block_body) => return Ok(beacon_block_body),
+                Err(err) => match err.downcast_ref::<NoBlockForSlotError>() {
+                    Some(_) => continue,
+                    None => return Err(err),
+                }
             }
-            slot += 1;
         }
 
         Err(format!(
             "Unable to get non empty beacon block in range [`{}`-`{}`)",
             start_slot,
-            start_slot + CHECK_SLOTS_FORWARD_LIMIT
+            finalized_slot
         ))?
     }
 


### PR DESCRIPTION

> send_hand_made_light_client_update() may be liable to stall if the attested slot lands on a skip slot with another 31 skip slots following this.
> The following lines https://github.com/aurora-is-near/rainbow-bridge/blob/9f66471a11a384d325d520e0f24a59ed8d74235d/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs#L469-L493
> The issue will be if in get_attesed_slot() the value attested_slot is a skip slow followed by 31 more skip slots. The call to get_non_empty_beacon_block_header(attested_slot)? will error and this error will be propagated.
> 
> Since last_finalized_slot_on_near is never updated we will always hit this error in send_hand_made_light_client_update().