### PR TITLE
Eth2-to-Near-relay: fix `LightClientUpdate` for new period

### DIFF
--- a/eth2near/eth2near-block-relay-rs/Cargo.lock
+++ b/eth2near/eth2near-block-relay-rs/Cargo.lock
@@ -1231,6 +1231,7 @@ dependencies = [
  "near-jsonrpc-primitives",
  "near-primitives 0.14.0",
  "near-sdk",
+ "primitive-types 0.7.3",
  "prometheus",
  "reqwest",
  "serde",

--- a/eth2near/eth2near-block-relay-rs/Cargo.toml
+++ b/eth2near/eth2near-block-relay-rs/Cargo.toml
@@ -32,6 +32,7 @@ hex = "*"
 toml = "0.5.9"
 atomic_refcell = "0.1.8"
 bitvec = "*"
+primitive-types = "0.7.3"
 
 near-jsonrpc-client = "=0.4.0-beta.0"
 near-crypto = "0.14.0"

--- a/eth2near/eth2near-block-relay-rs/src/beacon_rpc_client.rs
+++ b/eth2near/eth2near-block-relay-rs/src/beacon_rpc_client.rs
@@ -1,10 +1,10 @@
 use crate::execution_block_proof::ExecutionBlockProof;
 use crate::light_client_snapshot_with_proof::LightClientSnapshotWithProof;
-use contract_wrapper::utils;
 use crate::relay_errors::{
     ErrorOnJsonParse, ExecutionPayloadError, FailOnGettingJson, MissSyncAggregationError,
     NoBlockForSlotError, SignatureSlotNotFoundError,
 };
+use contract_wrapper::utils;
 use eth_types::eth2::BeaconBlockHeader;
 use eth_types::eth2::FinalizedHeaderUpdate;
 use eth_types::eth2::HeaderUpdate;
@@ -198,7 +198,8 @@ impl BeaconRPCClient {
         &self,
         beacon_block_hash: H256,
     ) -> Result<u64, Box<dyn Error>> {
-        let beacon_block_hash_str: String = utils::trim_quotes(serde_json::to_string(&beacon_block_hash)?);
+        let beacon_block_hash_str: String =
+            utils::trim_quotes(serde_json::to_string(&beacon_block_hash)?);
 
         let url = format!(
             "{}/{}/{}",
@@ -455,14 +456,13 @@ impl BeaconRPCClient {
                 Err(err) => match err.downcast_ref::<NoBlockForSlotError>() {
                     Some(_) => continue,
                     None => return Err(err),
-                }
+                },
             }
         }
 
         Err(format!(
             "Unable to get non empty beacon block in range [`{}`-`{}`)",
-            start_slot,
-            finalized_slot
+            start_slot, finalized_slot
         ))?
     }
 

--- a/eth2near/eth2near-block-relay-rs/src/beacon_rpc_client.rs
+++ b/eth2near/eth2near-block-relay-rs/src/beacon_rpc_client.rs
@@ -251,43 +251,8 @@ impl BeaconRPCClient {
     pub fn get_finality_light_client_update_with_sync_commity_update(
         &self,
     ) -> Result<LightClientUpdate, Box<dyn Error>> {
-        let url_finality = format!(
-            "{}/{}",
-            self.endpoint_url,
-            Self::URL_FINALITY_LIGHT_CLIENT_UPDATE_PATH
-        );
         let last_period = Self::get_period_for_slot(self.get_last_slot_number()?.as_u64());
-        let url_update = format!(
-            "{}/{}?start_period={}&count=1",
-            self.endpoint_url,
-            Self::URL_GET_LIGHT_CLIENT_UPDATE_API,
-            last_period
-        );
-        let finality_light_client_update_json_str =
-            self.get_json_from_raw_request(&url_finality)?;
-        let light_client_update_json_str = self.get_json_from_raw_request(&url_update)?;
-
-        let v: Value = serde_json::from_str(&finality_light_client_update_json_str)?;
-        let finality_light_client_update_json_str =
-            serde_json::to_string(&json!({"data": [v["data"]]}))?;
-
-        Ok(LightClientUpdate {
-            attested_beacon_header: Self::get_attested_header_from_light_client_update_json_str(
-                &finality_light_client_update_json_str,
-            )?,
-            sync_aggregate: Self::get_sync_aggregate_from_light_client_update_json_str(
-                &finality_light_client_update_json_str,
-            )?,
-            signature_slot: self.get_signature_slot(&finality_light_client_update_json_str)?,
-            finality_update: self.get_finality_update_from_light_client_update_json_str(
-                &finality_light_client_update_json_str,
-            )?,
-            sync_committee_update: Some(
-                Self::get_sync_committee_update_from_light_client_update_json_str(
-                    &light_client_update_json_str,
-                )?,
-            ),
-        })
+        self.get_light_client_update(last_period)
     }
 
     pub fn get_beacon_state(

--- a/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
+++ b/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
@@ -843,7 +843,7 @@ mod tests {
     #[test]
     fn test_finality_light_client_update_correctness() {
         const TREE_FINALITY_DEPTH: usize = 6;
-        const  TREE_FINALITY_INDEX: usize = 41;
+        const TREE_FINALITY_INDEX: usize = 41;
         const TREE_NEXT_SYNC_COMMITTEE_DEPTH: usize = 5;
         const TREE_NEXT_SYNC_COMMITTEE_INDEX: usize = 23;
 

--- a/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
+++ b/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
@@ -842,6 +842,11 @@ mod tests {
 
     #[test]
     fn test_finality_light_client_update_correctness() {
+        const TREE_FINALITY_DEPTH: usize = 6;
+        const  TREE_FINALITY_INDEX: usize = 41;
+        const TREE_NEXT_SYNC_COMMITTEE_DEPTH: usize = 5;
+        const TREE_NEXT_SYNC_COMMITTEE_INDEX: usize = 23;
+
         let config_for_test = get_test_config();
 
         let relay = get_relay(true, true, &config_for_test);
@@ -855,8 +860,8 @@ mod tests {
                 .beacon_header
                 .tree_hash_root(),
             branch.as_slice(),
-            6,
-            41,
+            TREE_FINALITY_DEPTH,
+            TREE_FINALITY_INDEX,
             light_client_update.attested_beacon_header.state_root.0
         ));
 
@@ -864,8 +869,8 @@ mod tests {
         assert!(merkle_proof::verify_merkle_proof(
             light_client_update.sync_committee_update.as_ref().unwrap().next_sync_committee.tree_hash_root(),
             branch.as_slice(),
-            5,
-            23,
+            TREE_NEXT_SYNC_COMMITTEE_DEPTH,
+            TREE_NEXT_SYNC_COMMITTEE_INDEX,
             light_client_update.finality_update.header_update.beacon_header.state_root.0
         ));
     }

--- a/eth2near/eth2near-block-relay-rs/src/execution_block_proof.rs
+++ b/eth2near/eth2near-block-relay-rs/src/execution_block_proof.rs
@@ -1,6 +1,6 @@
 use crate::beacon_block_body_merkle_tree::{BeaconBlockBodyMerkleTree, ExecutionPayloadMerkleTree};
-use eth2_hashing;
 use crate::relay_errors::MissExecutionPayload;
+use eth2_hashing;
 use ethereum_types::H256;
 use std::error::Error;
 use std::fmt;
@@ -122,7 +122,8 @@ impl ExecutionBlockProof {
         for (i, leaf) in branch.iter().enumerate().take(depth) {
             let ith_bit = (index >> i) & 0x01;
             if ith_bit == 1 {
-                merkle_root = eth2_hashing::hash32_concat(leaf.as_bytes(), &merkle_root)[..].to_vec();
+                merkle_root =
+                    eth2_hashing::hash32_concat(leaf.as_bytes(), &merkle_root)[..].to_vec();
             } else {
                 let mut input = merkle_root;
                 input.extend_from_slice(leaf.as_bytes());

--- a/eth2near/eth2near-block-relay-rs/src/hand_made_finality_light_client_update.rs
+++ b/eth2near/eth2near-block-relay-rs/src/hand_made_finality_light_client_update.rs
@@ -111,8 +111,7 @@ impl HandMadeFinalityLightClientUpdate {
             let sync_aggregate = signature_beacon_body
                 .sync_aggregate()
                 .map_err(|_| MissSyncAggregationError)?;
-            let sync_committee_bits: [u8; 64] =
-                Self::get_sync_committee_bits(sync_aggregate)?;
+            let sync_committee_bits: [u8; 64] = Self::get_sync_committee_bits(sync_aggregate)?;
             let sync_committee_bits_sum: u32 = sync_committee_bits
                 .into_iter()
                 .map(|x| x.count_ones())

--- a/eth2near/eth2near-block-relay-rs/src/init_contract.rs
+++ b/eth2near/eth2near-block-relay-rs/src/init_contract.rs
@@ -12,7 +12,8 @@ use tree_hash::TreeHash;
 
 const CURRENT_SYNC_COMMITTEE_INDEX: u32 = 54;
 const CURRENT_SYNC_COMMITTEE_TREE_DEPTH: u32 = consensus::floorlog2(CURRENT_SYNC_COMMITTEE_INDEX);
-const CURRENT_SYNC_COMMITTEE_TREE_INDEX: u32 = consensus::get_subtree_index(CURRENT_SYNC_COMMITTEE_INDEX);
+const CURRENT_SYNC_COMMITTEE_TREE_INDEX: u32 =
+    consensus::get_subtree_index(CURRENT_SYNC_COMMITTEE_INDEX);
 
 pub fn verify_light_client_snapshot(
     block_root: String,

--- a/eth2near/eth2near-block-relay-rs/src/last_slot_searcher.rs
+++ b/eth2near/eth2near-block-relay-rs/src/last_slot_searcher.rs
@@ -300,7 +300,7 @@ impl LastSlotSearcher {
                 Err(err) => match err.downcast_ref::<NoBlockForSlotError>() {
                     Some(_) => slot += 1,
                     None => return Err(err),
-                }
+                },
             }
         }
 
@@ -333,7 +333,7 @@ impl LastSlotSearcher {
                 Err(err) => match err.downcast_ref::<NoBlockForSlotError>() {
                     Some(_) => slot -= 1,
                     None => return Err(err),
-                }
+                },
             }
         }
 
@@ -618,12 +618,14 @@ mod tests {
             finalized_slot + 2,
         );
 
-        let last_submitted_block = last_slot_searcher.linear_search_backward(
-            finalized_slot + 1,
-            finalized_slot + 10,
-            &beacon_rpc_client,
-            &eth_client_contract,
-        ).unwrap();
+        let last_submitted_block = last_slot_searcher
+            .linear_search_backward(
+                finalized_slot + 1,
+                finalized_slot + 10,
+                &beacon_rpc_client,
+                &eth_client_contract,
+            )
+            .unwrap();
         assert_eq!(last_submitted_block, finalized_slot + 2);
 
         send_execution_blocks(
@@ -634,12 +636,14 @@ mod tests {
             config_for_test.slot_without_block - 1,
         );
 
-        let last_submitted_block = last_slot_searcher.linear_search_backward(
-            finalized_slot + 1,
-            config_for_test.right_bound_in_slot_search,
-            &beacon_rpc_client,
-            &eth_client_contract,
-        ).unwrap();
+        let last_submitted_block = last_slot_searcher
+            .linear_search_backward(
+                finalized_slot + 1,
+                config_for_test.right_bound_in_slot_search,
+                &beacon_rpc_client,
+                &eth_client_contract,
+            )
+            .unwrap();
         assert_eq!(last_submitted_block, config_for_test.slot_without_block);
     }
 
@@ -669,15 +673,17 @@ mod tests {
             config_for_test.slot_without_block - 2,
         );
 
-        let last_block_on_near = last_slot_searcher.linear_search_forward(
-            eth_client_contract
-                .get_finalized_beacon_block_slot()
-                .unwrap()
-                + 1,
-            config_for_test.right_bound_in_slot_search,
-            &beacon_rpc_client,
-            &eth_client_contract,
-        ).unwrap();
+        let last_block_on_near = last_slot_searcher
+            .linear_search_forward(
+                eth_client_contract
+                    .get_finalized_beacon_block_slot()
+                    .unwrap()
+                    + 1,
+                config_for_test.right_bound_in_slot_search,
+                &beacon_rpc_client,
+                &eth_client_contract,
+            )
+            .unwrap();
 
         assert_eq!(last_block_on_near, config_for_test.slot_without_block - 2);
 
@@ -689,15 +695,17 @@ mod tests {
             config_for_test.slot_without_block - 1,
         );
 
-        let last_block_on_near = last_slot_searcher.linear_search_forward(
-            eth_client_contract
-                .get_finalized_beacon_block_slot()
-                .unwrap()
-                + 1,
-            config_for_test.right_bound_in_slot_search,
-            &beacon_rpc_client,
-            &eth_client_contract,
-        ).unwrap();
+        let last_block_on_near = last_slot_searcher
+            .linear_search_forward(
+                eth_client_contract
+                    .get_finalized_beacon_block_slot()
+                    .unwrap()
+                    + 1,
+                config_for_test.right_bound_in_slot_search,
+                &beacon_rpc_client,
+                &eth_client_contract,
+            )
+            .unwrap();
 
         assert_eq!(last_block_on_near, config_for_test.slot_without_block);
     }

--- a/eth2near/eth2near-block-relay-rs/src/lib.rs
+++ b/eth2near/eth2near-block-relay-rs/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate core;
-
 pub mod beacon_block_body_merkle_tree;
 pub mod beacon_rpc_client;
 pub mod config;

--- a/eth2near/eth2near-block-relay-rs/src/test_utils.rs
+++ b/eth2near/eth2near-block-relay-rs/src/test_utils.rs
@@ -214,7 +214,9 @@ pub fn get_client_contract(
 
     match from_file {
         true => test_utils::init_contract_from_files(&mut eth_client_contract, config_for_test),
-        false => init_contract::init_contract(&config, &mut eth_client_contract, "".to_string()).unwrap(),
+        false => {
+            init_contract::init_contract(&config, &mut eth_client_contract, "".to_string()).unwrap()
+        }
     };
 
     Box::new(eth_client_contract)


### PR DESCRIPTION
We should submit the light client update once in a few epoch to the Eth2 Light Client on Near. 

First, for fetching Light Client Update from Eth2 we used the following API: "eth/v1/beacon/light_client/updates", which fetched the best Light Client Update for specified period. But we faced the problem: the finality block in such Light Client Update did not updated such often as we wanted to. Some time "best" Light Client Update could stay the same for the whole period. 

So we start to use API:  "eth/v1/beacon/light_client/finality_update/", which returns the LightClientUpdate with the last finality block. Unfortunatly such LightClientUpdate does not contain the next sync committee.

Luckily, the next sync committee changing only once per period. So, for fixed this problem we start use the Light Client Update from "eth/v1/beacon/light_client/finality_update/" and manuly included the next_sync_committee from "eth/v1/beacon/light_client/updates". 

However this solution was incorrect. We included not only next_sync_committee, but also the proof of inclusion the next_sync_committee to the finality beacon state. And if we have the another finalized block in the LightClientUpdate we can't just reuse this proof. The test "test_finality_light_client_update_correctness" will fail for the old realization during the checking of the proof for next_sync_committee. 

The correct solution is using "eth/v1/beacon/light_client/finality_update/" for the most of time and using "eth/v1/beacon/light_client/updates" in the beging of new period when we need next_sync_committee. This Light Client Update will be up to date in the begging of the new period. 