### PR TITLE
Eth2Near-relay: fix the contract initialization

### DIFF
--- a/eth2near/Cargo.toml
+++ b/eth2near/Cargo.toml
@@ -1,0 +1,18 @@
+[workspace]
+
+members = [
+    "contract_wrapper",
+    "eth2-contract-init",
+    "eth2near-block-relay-rs",
+    "eth_rpc_client",
+    "finality-update-verify",
+    "logger",
+]
+
+[patch]
+[patch.crates-io]
+eth2_ssz = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
+eth2_ssz_types = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
+eth2_hashing = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
+tree_hash = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
+eth2_serde_utils = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }

--- a/eth2near/contract_wrapper/Cargo.toml
+++ b/eth2near/contract_wrapper/Cargo.toml
@@ -20,10 +20,3 @@ serde = { version = "1.0", features = ["derive"] }
 eth-types = { path = "../../contracts/near/eth-types/", features = ["eip1559"]}
 workspaces = "0.5.0"
 anyhow = "1.0"
-
-[patch]
-[patch.crates-io]
-eth2_ssz = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-eth2_hashing = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-tree_hash = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-eth2_serde_utils = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }

--- a/eth2near/eth2-contract-init/Cargo.toml
+++ b/eth2near/eth2-contract-init/Cargo.toml
@@ -24,11 +24,3 @@ eth2near-logger = { path = "../logger" }
 [dev-dependencies]
 workspaces = "0.5.0"
 tokio = { version = "1.1", features = ["macros", "rt", "time"] }
-
-[patch]
-[patch.crates-io]
-eth2_ssz = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-eth2_ssz_types = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-eth2_hashing = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-tree_hash = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-eth2_serde_utils = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }

--- a/eth2near/eth2-contract-init/src/init_contract.rs
+++ b/eth2near/eth2-contract-init/src/init_contract.rs
@@ -58,10 +58,14 @@ pub fn init_contract(
     );
     let eth1_rpc_client = Eth1RPCClient::new(&config.eth1_endpoint);
 
-    let light_client_update = beacon_rpc_client
+    let light_client_update_with_next_sync_committee = beacon_rpc_client
         .get_finality_light_client_update_with_sync_commity_update()
         .expect("Error on fetching finality light client update with sync committee update");
-    let finality_slot = light_client_update
+    let finality_light_client_update = beacon_rpc_client
+        .get_finality_light_client_update()
+        .expect("Error on fetching finality light client update");
+
+    let finality_slot = finality_light_client_update
         .finality_update
         .header_update
         .beacon_header
@@ -70,7 +74,7 @@ pub fn init_contract(
     let block_id = format!("{}", finality_slot);
 
     let finalized_header: ExtendedBeaconBlockHeader =
-        ExtendedBeaconBlockHeader::from(light_client_update.finality_update.header_update);
+        ExtendedBeaconBlockHeader::from(finality_light_client_update.finality_update.header_update);
     let finalized_body = beacon_rpc_client
         .get_beacon_block_body_for_block_id(&block_id)
         .expect("Error on fetching finalized body");
@@ -85,7 +89,7 @@ pub fn init_contract(
         )
         .expect("Error on fetching finalized execution header");
 
-    let next_sync_committee = light_client_update
+    let next_sync_committee = light_client_update_with_next_sync_committee
         .sync_committee_update
         .expect("No sync_committee update in light client update")
         .next_sync_committee;

--- a/eth2near/eth2near-block-relay-rs/Cargo.toml
+++ b/eth2near/eth2near-block-relay-rs/Cargo.toml
@@ -49,11 +49,3 @@ thread = "*"
 [dev-dependencies]
 workspaces = "0.5.0"
 eth2-contract-init = { path = "../eth2-contract-init" }
-
-[patch]
-[patch.crates-io]
-eth2_ssz = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-eth2_ssz_types = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-eth2_hashing = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-tree_hash = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-eth2_serde_utils = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }

--- a/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
+++ b/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
@@ -579,7 +579,7 @@ impl Eth2NearRelay {
             debug!(target: "relay", "Finalized period on ETH and NEAR are different. Fetching sync commity update");
             return_on_fail!(
                 self.beacon_rpc_client
-                    .get_finality_light_client_update_with_sync_commity_update(),
+                    .get_light_client_update_for_last_period(),
                 "Error on getting light client update. Skipping sending light client update"
             )
         };
@@ -853,7 +853,7 @@ mod tests {
 
         let light_client_update = relay
             .beacon_rpc_client
-            .get_finality_light_client_update_with_sync_commity_update()
+            .get_light_client_update_for_last_period()
             .unwrap();
 
         let branch: Vec<ethereum_types::H256> = light_client_update

--- a/eth2near/eth_rpc_client/Cargo.toml
+++ b/eth2near/eth_rpc_client/Cargo.toml
@@ -34,12 +34,3 @@ prometheus = { version = "0.9", features = ["process"] }
 lazy_static = "1.4"
 warp = "0.2"
 thread = "*"
-
-
-[patch]
-[patch.crates-io]
-eth2_ssz = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-eth2_ssz_types = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-eth2_hashing = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-tree_hash = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-eth2_serde_utils = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }

--- a/eth2near/eth_rpc_client/src/beacon_rpc_client.rs
+++ b/eth2near/eth_rpc_client/src/beacon_rpc_client.rs
@@ -246,7 +246,13 @@ impl BeaconRPCClient {
         })
     }
 
-    pub fn get_finality_light_client_update_with_sync_commity_update(
+    /// Returns the best light client update for the last period
+    ///
+    /// Best is defined by (in order of priority):
+    /// - Is finalized update
+    /// - Has most bits
+    /// - Oldest update
+    pub fn get_light_client_update_for_last_period(
         &self,
     ) -> Result<LightClientUpdate, Box<dyn Error>> {
         let last_period = Self::get_period_for_slot(self.get_last_slot_number()?.as_u64());

--- a/eth2near/eth_rpc_client/src/utils.rs
+++ b/eth2near/eth_rpc_client/src/utils.rs
@@ -11,10 +11,5 @@ pub fn trim_quotes(s: String) -> String {
 }
 
 pub fn read_json_file_from_data_dir(file_name: &str) -> std::string::String {
-    let mut json_file_path = std::env::current_exe().unwrap();
-    json_file_path.pop();
-    json_file_path.push("../../../data");
-    json_file_path.push(file_name);
-
-    std::fs::read_to_string(json_file_path).expect("Unable to read file")
+    std::fs::read_to_string(format!("data/{}", file_name)).expect("Unable to read file")
 }

--- a/eth2near/finality-update-verify/Cargo.toml
+++ b/eth2near/finality-update-verify/Cargo.toml
@@ -16,11 +16,3 @@ eth2_to_near_relay = { path = "../eth2near-block-relay-rs"}
 serde_json = "1.0.74"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5.9"
-
-[patch]
-[patch.crates-io]
-eth2_ssz = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-eth2_ssz_types = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-eth2_hashing = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-tree_hash = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }
-eth2_serde_utils = { git = "https://github.com/aurora-is-near/lighthouse.git", rev = "b624c3f0d3c5bc9ea46faa14c9cb2d90ee1e1dec" }


### PR DESCRIPTION
* Get the light client update for last finality slot instead the some slot in current period during initialization
* Add workspace for eth2near relay