### PR TITLE
Eth2Near-relayer: fix decoding success status

### DIFF
--- a/eth2near/contract_wrapper/src/utils.rs
+++ b/eth2near/contract_wrapper/src/utils.rs
@@ -13,11 +13,10 @@ pub fn trim_quotes(s: String) -> String {
 }
 
 pub fn status_as_success_decoded(status: FinalExecutionStatus) -> Option<Vec<u8>> {
-    let success = match status {
+    match status {
         FinalExecutionStatus::SuccessValue(value) => Some(value),
         _ => None,
-    };
-    success.and_then(|value| near_sdk::base64::decode(&value).ok())
+    }
 }
 
 pub fn new_near_rpc_client(timeout: Option<std::time::Duration>) -> reqwest::Client {


### PR DESCRIPTION
Fix `SuccessValue` in the `FinalExecutionStatus` is decoded twice because the macro `#[serde(with = "base64_format"` has been added in `near-sdk = "4.1.1"`