### PR TITLE
Eth2Near-relayer: fix sending update for the next period

### DIFF
--- a/eth2near/contract_wrapper/src/dao_contract.rs
+++ b/eth2near/contract_wrapper/src/dao_contract.rs
@@ -139,7 +139,6 @@ mod tests {
         SyncAggregate, SyncCommitteeBits,
     };
     use near_crypto::{KeyType, PublicKey};
-    use near_primitives::serialize::to_base64;
     use near_primitives::types::AccountId;
     use near_primitives::views::{
         ExecutionOutcomeView, ExecutionOutcomeWithIdView, ExecutionStatusView,
@@ -152,7 +151,7 @@ mod tests {
     use std::time::Duration;
 
     fn get_default_result() -> FinalExecutionOutcomeView {
-        let status_str = to_base64("215");
+        let status_str = "215";
         FinalExecutionOutcomeView {
             status: FinalExecutionStatus::SuccessValue(status_str.into()),
             transaction: SignedTransactionView {

--- a/eth2near/eth2-contract-init/src/init_contract.rs
+++ b/eth2near/eth2-contract-init/src/init_contract.rs
@@ -64,8 +64,13 @@ pub fn init_contract(
     );
     let eth1_rpc_client = Eth1RPCClient::new(&config.eth1_endpoint);
 
+    let last_period = BeaconRPCClient::get_period_for_slot(beacon_rpc_client
+        .get_last_slot_number()
+        .expect("Error on fetching last slot number")
+        .as_u64());
+
     let light_client_update_with_next_sync_committee = beacon_rpc_client
-        .get_light_client_update_for_last_period()
+        .get_light_client_update(last_period)
         .expect("Error on fetching finality light client update with sync committee update");
     let finality_light_client_update = beacon_rpc_client
         .get_finality_light_client_update()

--- a/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
+++ b/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
@@ -524,7 +524,7 @@ impl Eth2NearRelay {
             debug!(target: "relay", "Finalized period on ETH and NEAR are different. Fetching sync commity update");
             return_on_fail!(
                 self.beacon_rpc_client
-                    .get_light_client_update_for_last_period(),
+                    .get_light_client_update(last_eth2_period_on_near_chain + 1),
                 "Error on getting light client update. Skipping sending light client update"
             )
         };

--- a/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
+++ b/eth2near/eth2near-block-relay-rs/src/eth2near_relay.rs
@@ -794,9 +794,14 @@ mod tests {
 
         let relay = get_relay(true, &config_for_test);
 
+        let last_period = BeaconRPCClient::get_period_for_slot(relay.beacon_rpc_client
+            .get_last_slot_number()
+            .unwrap()
+            .as_u64());
+
         let light_client_update = relay
             .beacon_rpc_client
-            .get_light_client_update_for_last_period()
+            .get_light_client_update(last_period)
             .unwrap();
 
         let branch: Vec<ethereum_types::H256> = light_client_update

--- a/eth2near/eth_rpc_client/src/beacon_rpc_client.rs
+++ b/eth2near/eth_rpc_client/src/beacon_rpc_client.rs
@@ -337,19 +337,6 @@ impl BeaconRPCClient {
         })
     }
 
-    /// Returns the best light client update for the last period
-    ///
-    /// Best is defined by (in order of priority):
-    /// - Is finalized update
-    /// - Has most bits
-    /// - Oldest update
-    pub fn get_light_client_update_for_last_period(
-        &self,
-    ) -> Result<LightClientUpdate, Box<dyn Error>> {
-        let last_period = Self::get_period_for_slot(self.get_last_slot_number()?.as_u64());
-        self.get_light_client_update(last_period)
-    }
-
     pub fn get_beacon_state(
         &self,
         state_id: &str,


### PR DESCRIPTION
Fix handling the case when the gap between NEAR and Ethereum is more than one period. Send the update for the next period, not for the last one.