### PR TITLE
CI: Use the latest `nearcore` version

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ on:
 name: E2E tests
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -30,8 +30,10 @@ jobs:
 
     name: ${{ matrix.job-name }}
     steps:
-      - name: Install LFS
-        run: apt-get install git-lfs
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
 
       - name: Clone the repository
         uses: actions/checkout@v3

--- a/utils/scripts/prepare.sh
+++ b/utils/scripts/prepare.sh
@@ -38,27 +38,27 @@ esac
 if test -z "$LOCAL_CORE_SRC"
 then
   echo "near-core home not specified..."
-  # if [ "$MACHINE" == "Linux" ]; then
-  #   if [[ -z "$NEAR_CHAIN_ID" ]]; then
-  #     NEAR_CHAIN_ID=testnet
-  #   fi
-  #   NEAR_RELEASE=$(curl https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/$NEAR_CHAIN_ID/latest_release)
-  #   NEAR_DEPLOY=$(curl https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/$NEAR_CHAIN_ID/latest_deploy)
-  #   NEAR_CORE_BINARY_URL="https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Linux/$NEAR_RELEASE/$NEAR_DEPLOY/neard"
-  #   NEAR_CORE_BINARY_DIR="$CORE_SRC/target/debug"
-  #   NEAR_CORE_BINARY_PATH="$NEAR_CORE_BINARY_DIR/neard"
-  #   mkdir -p $NEAR_CORE_BINARY_DIR
-  #   status=$(curl $NEAR_CORE_BINARY_URL --output $NEAR_CORE_BINARY_PATH --write-out "%{http_code}")
-  #   if [ "$status" != "200" ]; then
-  #     echo "Download neard failed"
-  #     exit 1
-  #   fi
-  #   chmod +x $NEAR_CORE_BINARY_PATH
-  # else
+  if [ "$MACHINE" == "Linux" ]; then
+    if [[ -z "$NEAR_CHAIN_ID" ]]; then
+      NEAR_CHAIN_ID=testnet
+    fi
+    NEAR_RELEASE=$(curl https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/$NEAR_CHAIN_ID/latest_release)
+    NEAR_DEPLOY=$(curl https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/$NEAR_CHAIN_ID/latest_deploy)
+    NEAR_CORE_BINARY_URL="https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Linux/$NEAR_RELEASE/$NEAR_DEPLOY/neard"
+    NEAR_CORE_BINARY_DIR="$CORE_SRC/target/debug"
+    NEAR_CORE_BINARY_PATH="$NEAR_CORE_BINARY_DIR/neard"
+    mkdir -p $NEAR_CORE_BINARY_DIR
+    status=$(curl $NEAR_CORE_BINARY_URL --output $NEAR_CORE_BINARY_PATH --write-out "%{http_code}")
+    if [ "$status" != "200" ]; then
+      echo "Download neard failed"
+      exit 1
+    fi
+    chmod +x $NEAR_CORE_BINARY_PATH
+  else
     git clone --depth 1 --branch "1.31.0" "https://github.com/nearprotocol/nearcore" $CORE_SRC
     cd $CORE_SRC
     cargo build --package neard --bin neard
-  # fi
+  fi
 else
   echo "Linking the specified local repo from ${LOCAL_CORE_SRC} to ${CORE_SRC}"
   ln -s $LOCAL_CORE_SRC $CORE_SRC


### PR DESCRIPTION
- Replace `self-hosted` with `ubuntu-latest` to fix the error related to the introduced ipv6 in the [near core  1.32.0](https://github.com/near/nearcore/blob/1.32.0/chain/network/src/tcp.rs#L65)  `thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 99, kind: AddrNotAvailable, message: "Cannot assign requested address" }', chain/network/src/tcp.rs:186:48`

- Revert `utils/scripts/prepare.sh` changes.