### PR TITLE
Contract wrapper: move some crates to `dev-dependencies`

### DIFF
--- a/eth2near/contract_wrapper/Cargo.toml
+++ b/eth2near/contract_wrapper/Cargo.toml
@@ -18,8 +18,11 @@ serde_json = "1.0.74"
 serde = { version = "1.0", features = ["derive"] }
 eth-types = { path = "../../contracts/near/eth-types/" }
 eth2-utility = { path = "../../contracts/near/eth2-utility/" }
+workspaces = { version = "0.7", optional = true }
 
 [dev-dependencies]
-workspaces = "0.7"
 futures = "0.3.21"
 anyhow = "1.0"
+
+[features]
+sandbox = ["workspaces"]

--- a/eth2near/contract_wrapper/Cargo.toml
+++ b/eth2near/contract_wrapper/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 borsh = "0.9.3"
-futures = "0.3.21"
 async-std = "1.12.0"
 near-sdk = "4.1.1"
 near-jsonrpc-client = "0.5.0"
@@ -19,5 +18,8 @@ serde_json = "1.0.74"
 serde = { version = "1.0", features = ["derive"] }
 eth-types = { path = "../../contracts/near/eth-types/" }
 eth2-utility = { path = "../../contracts/near/eth2-utility/" }
+
+[dev-dependencies]
 workspaces = "0.7"
+futures = "0.3.21"
 anyhow = "1.0"

--- a/eth2near/contract_wrapper/rust-toolchain
+++ b/eth2near/contract_wrapper/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.67.1"
+channel = "1.69.0"

--- a/eth2near/contract_wrapper/src/dao_eth_client_contract.rs
+++ b/eth2near/contract_wrapper/src/dao_eth_client_contract.rs
@@ -2,9 +2,9 @@ use crate::dao_contract::DAOContract;
 use crate::dao_types;
 use crate::eth_client_contract::EthClientContract;
 use crate::eth_client_contract_trait::EthClientContractTrait;
+use eth2_utility::types::ClientMode;
 use eth_types::eth2::{LightClientState, LightClientUpdate};
 use eth_types::{BlockHeader, H256};
-use eth2_utility::types::ClientMode;
 use near_primitives::views::FinalExecutionOutcomeView;
 use std::error::Error;
 use std::str::FromStr;
@@ -100,7 +100,7 @@ impl EthClientContractTrait for DaoEthClientContract {
         self.eth_client_contract.get_light_client_state()
     }
 
-   fn get_last_block_number(&self) -> Result<u64, Box<dyn Error>> {
+    fn get_last_block_number(&self) -> Result<u64, Box<dyn Error>> {
         self.eth_client_contract.get_last_block_number()
     }
 

--- a/eth2near/contract_wrapper/src/eth_client_contract.rs
+++ b/eth2near/contract_wrapper/src/eth_client_contract.rs
@@ -2,11 +2,11 @@ use crate::contract_wrapper_trait::ContractWrapper;
 use crate::eth_client_contract_trait::EthClientContractTrait;
 use crate::eth_network::EthNetwork;
 use borsh::BorshDeserialize;
+use eth2_utility::types::ClientMode;
 use eth_types::eth2::{
     ExtendedBeaconBlockHeader, LightClientState, LightClientUpdate, SyncCommittee,
 };
 use eth_types::{BlockHeader, H256};
-use eth2_utility::types::ClientMode;
 use near_primitives::borsh::BorshSerialize;
 use near_primitives::types::AccountId;
 use near_primitives::views::FinalExecutionOutcomeView;
@@ -25,9 +25,7 @@ pub struct EthClientContract {
 impl EthClientContract {
     /// Constructor for `EthClientContract`
     pub fn new(contract_wrapper: Box<dyn ContractWrapper>) -> Self {
-        EthClientContract {
-            contract_wrapper,
-        }
+        EthClientContract { contract_wrapper }
     }
 
     /// Initializes the Ethereum Light Client Contract on NEAR.
@@ -137,7 +135,7 @@ impl EthClientContractTrait for EthClientContract {
     fn get_client_mode(&self) -> Result<ClientMode, Box<dyn Error>> {
         let res = self.contract_wrapper.call_view_function(
             "get_client_mode".to_string(),
-            json!({}).to_string().into_bytes()
+            json!({}).to_string().into_bytes(),
         )?;
 
         let mode: ClientMode = ClientMode::try_from_slice(&res)?;
@@ -239,9 +237,10 @@ mod tests {
         }
 
         pub fn submit_block(&mut self, eth_client: &mut EthClientContract) {
-            eth_client.send_headers(
-                    &vec![self.execution_blocks[self.current_execution_block].clone()],
-                )
+            eth_client
+                .send_headers(&vec![
+                    self.execution_blocks[self.current_execution_block].clone()
+                ])
                 .unwrap();
 
             self.current_execution_block += 1;
@@ -253,7 +252,8 @@ mod tests {
         }
 
         pub fn submit_update(&mut self, eth_client: &mut EthClientContract) {
-            eth_client.send_light_client_update(
+            eth_client
+                .send_light_client_update(
                     self.light_client_updates[self.current_light_client_update].clone(),
                 )
                 .unwrap();

--- a/eth2near/contract_wrapper/src/eth_client_contract_trait.rs
+++ b/eth2near/contract_wrapper/src/eth_client_contract_trait.rs
@@ -1,6 +1,6 @@
+use eth2_utility::types::ClientMode;
 use eth_types::eth2::{LightClientState, LightClientUpdate};
 use eth_types::{BlockHeader, H256};
-use eth2_utility::types::ClientMode;
 use near_primitives::views::FinalExecutionOutcomeView;
 use std::error::Error;
 
@@ -25,7 +25,7 @@ pub trait EthClientContractTrait {
     /// * `headers` - the list of headers for submission to Eth Client
     fn send_headers(
         &mut self,
-        headers: &[BlockHeader]
+        headers: &[BlockHeader],
     ) -> Result<FinalExecutionOutcomeView, Box<dyn std::error::Error>>;
 
     fn get_client_mode(&self) -> Result<ClientMode, Box<dyn Error>>;

--- a/eth2near/contract_wrapper/src/file_eth_client_contract.rs
+++ b/eth2near/contract_wrapper/src/file_eth_client_contract.rs
@@ -1,8 +1,8 @@
 use crate::eth_client_contract::EthClientContract;
 use crate::eth_client_contract_trait::EthClientContractTrait;
+use eth2_utility::types::ClientMode;
 use eth_types::eth2::{LightClientState, LightClientUpdate};
 use eth_types::{BlockHeader, H256};
-use eth2_utility::types::ClientMode;
 use near_primitives::views::FinalExecutionOutcomeView;
 use std::error::Error;
 use std::fs::File;
@@ -67,7 +67,7 @@ impl EthClientContractTrait for FileEthClientContract {
 
     fn send_headers(
         &mut self,
-        headers: &[BlockHeader]
+        headers: &[BlockHeader],
     ) -> Result<FinalExecutionOutcomeView, Box<dyn std::error::Error>> {
         for header in headers {
             self.blocks_headers_file

--- a/eth2near/contract_wrapper/src/lib.rs
+++ b/eth2near/contract_wrapper/src/lib.rs
@@ -10,5 +10,6 @@ pub mod file_eth_client_contract;
 pub mod near_contract_wrapper;
 pub mod near_network;
 pub mod near_rpc_client;
+#[cfg(test)]
 pub mod sandbox_contract_wrapper;
 pub mod utils;

--- a/eth2near/contract_wrapper/src/lib.rs
+++ b/eth2near/contract_wrapper/src/lib.rs
@@ -10,6 +10,6 @@ pub mod file_eth_client_contract;
 pub mod near_contract_wrapper;
 pub mod near_network;
 pub mod near_rpc_client;
-#[cfg(test)]
+#[cfg(feature = "sandbox")]
 pub mod sandbox_contract_wrapper;
 pub mod utils;

--- a/eth2near/eth2-contract-init/Cargo.toml
+++ b/eth2near/eth2-contract-init/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 [dependencies]
 tree_hash = { git = "https://github.com/aurora-is-near/lighthouse.git", tag = "v3.5.1-wasm" }
 merkle_proof = { git = "https://github.com/aurora-is-near/lighthouse.git", tag = "v3.5.1-wasm" }
-types =  { git = "https://github.com/aurora-is-near/lighthouse.git", tag = "v3.5.1-wasm" }
-eth2_to_near_relay = { path = "../eth2near-block-relay-rs"}
+types = { git = "https://github.com/aurora-is-near/lighthouse.git", tag = "v3.5.1-wasm" }
+eth2_to_near_relay = { path = "../eth2near-block-relay-rs" }
 eth_rpc_client = { path = "../eth_rpc_client" }
 eth-types = { path = "../../contracts/near/eth-types/" }
-eth2-utility  = { path = "../../contracts/near/eth2-utility" }
+eth2-utility = { path = "../../contracts/near/eth2-utility" }
 contract_wrapper = { path = "../contract_wrapper" }
 log = { version = "0.4", features = ["std", "serde"] }
 clap = { version = "3.1.6", features = ["derive"] }
@@ -26,3 +26,4 @@ dotenv = "0.15.0"
 [dev-dependencies]
 workspaces = "0.7"
 tokio = { version = "1.1", features = ["macros", "rt", "time"] }
+contract_wrapper = { path = "../contract_wrapper", features = ["sandbox"] }

--- a/eth2near/eth2near-block-relay-rs/Cargo.toml
+++ b/eth2near/eth2near-block-relay-rs/Cargo.toml
@@ -50,3 +50,4 @@ dotenv = "0.15.0"
 [dev-dependencies]
 workspaces = "0.7"
 eth2-contract-init = { path = "../eth2-contract-init" }
+contract_wrapper = { path = "../contract_wrapper", features = ["sandbox"] }

--- a/eth2near/eth2near-block-relay-rs/src/test_utils.rs
+++ b/eth2near/eth2near-block-relay-rs/src/test_utils.rs
@@ -247,15 +247,9 @@ pub fn get_client_contract(
     Box::new(eth_client_contract)
 }
 
-pub fn get_relay(
-    from_file: bool,
-    config_for_test: &ConfigForTests,
-) -> Eth2NearRelay {
+pub fn get_relay(from_file: bool, config_for_test: &ConfigForTests) -> Eth2NearRelay {
     let config = get_config(config_for_test);
-    Eth2NearRelay::init(
-        &config,
-        get_client_contract(from_file, config_for_test)
-    )
+    Eth2NearRelay::init(&config, get_client_contract(from_file, config_for_test))
 }
 
 pub fn get_relay_with_update_from_file(
@@ -270,16 +264,10 @@ pub fn get_relay_with_update_from_file(
         config.include_next_sync_committee_to_light_client = true;
     }
 
-    Eth2NearRelay::init(
-        &config,
-        get_client_contract(from_file, config_for_test)
-    )
+    Eth2NearRelay::init(&config, get_client_contract(from_file, config_for_test))
 }
 
-pub fn get_relay_from_slot(
-    slot: u64,
-    config_for_test: &ConfigForTests,
-) -> Eth2NearRelay {
+pub fn get_relay_from_slot(slot: u64, config_for_test: &ConfigForTests) -> Eth2NearRelay {
     let config = get_config(config_for_test);
 
     let (relay_account, contract) = create_contract(&config_for_test);
@@ -289,8 +277,5 @@ pub fn get_relay_from_slot(
 
     init_contract_from_specific_slot(&mut eth_client_contract, slot, config_for_test);
 
-    Eth2NearRelay::init(
-        &config,
-        Box::new(eth_client_contract)
-    )
+    Eth2NearRelay::init(&config, Box::new(eth_client_contract))
 }


### PR DESCRIPTION
The `workspaces` is a heavy crate used just for tests, so it shouldn't be compiled in release apps.
In this PR:
- Hide the sandbox wrapper code under the feature flag.
- Apply cargo fmt to the `contract_wrapper` crate