### PR TITLE
Fix Eth2Near relayer build

### DIFF
--- a/eth2near/Cargo.lock
+++ b/eth2near/Cargo.lock
@@ -1392,7 +1392,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thread",
  "tokio 1.19.2",
  "toml",
  "tree_hash",
@@ -1435,7 +1434,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thread",
  "tokio 1.19.2",
  "toml",
  "tree_hash",
@@ -4717,12 +4715,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "thread"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe9c0e959dd1e7b871071b51bc674380d1889cd4fed9f4b3b1f5c1772d9f796"
 
 [[package]]
 name = "thread_local"

--- a/eth2near/eth2near-block-relay-rs/Cargo.toml
+++ b/eth2near/eth2near-block-relay-rs/Cargo.toml
@@ -44,7 +44,6 @@ near-jsonrpc-primitives = "0.16.0"
 prometheus = { version = "0.9", features = ["process"] }
 lazy_static = "1.4"
 warp = "0.2"
-thread = "*"
 dotenv = "0.15.0"
 
 [dev-dependencies]

--- a/eth2near/eth_rpc_client/Cargo.toml
+++ b/eth2near/eth_rpc_client/Cargo.toml
@@ -33,5 +33,4 @@ bitvec = "1.0.0"
 prometheus = { version = "0.9", features = ["process"] }
 lazy_static = "1.4"
 warp = "0.2"
-thread = "*"
 dotenv = "0.15.0"


### PR DESCRIPTION
Remove `thread` crate to fix the Eth2Near relayer build